### PR TITLE
Implement Redis caching and academic retriever

### DIFF
--- a/storm_loop/cache.py
+++ b/storm_loop/cache.py
@@ -1,0 +1,51 @@
+import asyncio
+import hashlib
+import json
+from typing import Any, Dict, Optional
+
+
+class RedisAcademicCache:
+    """Simple Redis-based cache with in-memory fallback."""
+
+    def __init__(self, redis_url: str = "redis://localhost:6379", ttl: int = 3600) -> None:
+        self.ttl = ttl
+        try:
+            import redis.asyncio as redis  # type: ignore
+            self._redis = redis.from_url(redis_url, decode_responses=True)
+            self.enabled = True
+        except Exception:
+            # Fallback to in-memory dictionary if redis is unavailable
+            self._store: Dict[str, str] = {}
+            self.enabled = False
+
+    def generate_cache_key(self, source: str, query: str, filters: Optional[Dict[str, Any]] = None) -> str:
+        filters = filters or {}
+        query_hash = hashlib.sha256(query.encode("utf-8")).hexdigest()
+        filter_hash = hashlib.sha256(json.dumps(filters, sort_keys=True).encode("utf-8")).hexdigest()
+        return f"academic:{source}:{query_hash}:{filter_hash}"
+
+    async def get_cached_search(self, key: str) -> Optional[Dict[str, Any]]:
+        if self.enabled:
+            value = await self._redis.get(key)
+            if value:
+                return json.loads(value)
+            return None
+        # memory fallback
+        value = self._store.get(key)
+        return json.loads(value) if value else None
+
+    async def cache_search_result(self, key: str, result: Dict[str, Any], ttl: Optional[int] = None) -> None:
+        ttl = ttl or self.ttl
+        data = json.dumps(result)
+        if self.enabled:
+            await self._redis.set(key, data, ex=ttl)
+        else:
+            self._store[key] = data
+            # naive in-memory TTL handling
+            asyncio.get_event_loop().call_later(ttl, lambda: self._store.pop(key, None))
+
+    async def invalidate(self, key: str) -> None:
+        if self.enabled:
+            await self._redis.delete(key)
+        else:
+            self._store.pop(key, None)

--- a/storm_loop/config.py
+++ b/storm_loop/config.py
@@ -1,0 +1,12 @@
+import os
+
+
+class Settings:
+    """Configuration values for the system."""
+
+    REDIS_URL: str = os.getenv("REDIS_URL", "redis://localhost:6379")
+    CACHE_TTL: int = int(os.getenv("CACHE_TTL", "3600"))
+
+
+def get_settings() -> Settings:
+    return Settings()

--- a/storm_loop/retriever.py
+++ b/storm_loop/retriever.py
@@ -1,0 +1,59 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .cache import RedisAcademicCache
+
+
+@dataclass
+class SearchResult:
+    source: str
+    query: str
+    results: Any
+
+
+class OpenAlexClient:
+    async def search(self, query: str, filters: Optional[Dict[str, Any]] = None) -> Any:
+        await asyncio.sleep(0.1)
+        return {"source": "openalex", "query": query, "filters": filters or {}}
+
+
+class CrossrefClient:
+    async def search(self, query: str, filters: Optional[Dict[str, Any]] = None) -> Any:
+        await asyncio.sleep(0.1)
+        return {"source": "crossref", "query": query, "filters": filters or {}}
+
+
+class PerplexityClient:
+    async def search(self, query: str) -> Any:
+        await asyncio.sleep(0.1)
+        return {"source": "perplexity", "query": query}
+
+
+class SearchClientFactory:
+    def __init__(self) -> None:
+        self.openalex = OpenAlexClient()
+        self.crossref = CrossrefClient()
+        self.perplexity = PerplexityClient()
+
+
+class AcademicRetrieverAgent:
+    def __init__(self, cache: RedisAcademicCache, clients: Optional[SearchClientFactory] = None) -> None:
+        self.cache = cache
+        self.clients = clients or SearchClientFactory()
+
+    async def search(self, query: str, filters: Optional[Dict[str, Any]] = None) -> SearchResult:
+        filters = filters or {}
+        key = self.cache.generate_cache_key("openalex", query, filters)
+        cached = await self.cache.get_cached_search(key)
+        if cached:
+            return SearchResult(source="openalex", query=query, results=cached)
+
+        try:
+            result = await self.clients.openalex.search(query, filters)
+        except Exception:
+            result = await self.clients.perplexity.search(query)
+            return SearchResult(source="perplexity", query=query, results=result)
+
+        await self.cache.cache_search_result(key, result)
+        return SearchResult(source="openalex", query=query, results=result)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,19 @@
+import asyncio
+
+from storm_loop.cache import RedisAcademicCache
+
+
+def test_cache_roundtrip():
+    async def run():
+        cache = RedisAcademicCache()
+        key = cache.generate_cache_key("openalex", "example query", {})
+
+        await cache.cache_search_result(key, {"value": 42}, ttl=1)
+        result = await cache.get_cached_search(key)
+        assert result == {"value": 42}
+
+        await asyncio.sleep(1.1)
+        expired = await cache.get_cached_search(key)
+        assert expired is None
+
+    asyncio.run(run())

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,0 +1,19 @@
+import asyncio
+
+from storm_loop.cache import RedisAcademicCache
+from storm_loop.retriever import AcademicRetrieverAgent
+
+
+def test_retriever_caches_result():
+    async def run():
+        cache = RedisAcademicCache()
+        agent = AcademicRetrieverAgent(cache)
+
+        result1 = await agent.search("quantum physics")
+        assert result1.source == "openalex"
+
+        # second call should hit cache
+        result2 = await agent.search("quantum physics")
+        assert result2.results == result1.results
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add async RedisAcademicCache with in-memory fallback
- create AcademicRetrieverAgent with simple search clients
- provide configuration helpers
- add tests for caching and retriever agent

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863defe49ac8322a8d659bf80b913f6