### PR TITLE
Add advanced caching with metrics and decorator-based integration

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -17,3 +17,26 @@ def test_cache_roundtrip():
         assert expired is None
 
     asyncio.run(run())
+
+
+def test_cache_metrics_and_lru():
+    async def run():
+        cache = RedisAcademicCache(memory_capacity=1)
+        key1 = cache.generate_cache_key("openalex", "q1", {})
+        await cache.cache_search_result(key1, {"num": 1})
+
+        # hit should increase metrics.hits
+        assert await cache.get_cached_search(key1) == {"num": 1}
+
+        key2 = cache.generate_cache_key("openalex", "q2", {})
+        # miss increments metrics.misses
+        assert await cache.get_cached_search(key2) is None
+
+        metrics = cache.metrics.snapshot()
+        assert metrics["hits"] == 1
+        assert metrics["misses"] >= 1
+
+        # storing second key should evict the first due to LRU capacity=1
+        await cache.cache_search_result(key2, {"num": 2})
+        assert await cache.get_cached_search(key1) is None
+    asyncio.run(run())

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -12,8 +12,10 @@ def test_retriever_caches_result():
         result1 = await agent.search("quantum physics")
         assert result1.source == "openalex"
 
-        # second call should hit cache
+        # second call should hit cache and metrics should report a hit
         result2 = await agent.search("quantum physics")
         assert result2.results == result1.results
+        metrics = cache.metrics.snapshot()
+        assert metrics["hits"] >= 1
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- add `CacheMetrics` and `LRUMemoryCache`
- refactor `RedisAcademicCache` for metrics and LRU fallback
- add cache decorator for transparent caching
- integrate decorator in `SearchClientFactory`
- simplify `AcademicRetrieverAgent` search method
- expand unit tests to cover metrics and LRU functionality

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ff16f684832284b71d1268e02565