### PR TITLE
Add advanced caching with metrics and decorator-based integration

### DIFF
--- a/storm_loop/cache.py
+++ b/storm_loop/cache.py
@@ -1,22 +1,159 @@
-import asyncio
+"""Caching utilities with metrics and multi-backend support."""
+
 import hashlib
 import json
+import time
+from abc import ABC, abstractmethod
+from collections import OrderedDict
 from typing import Any, Dict, Optional
 
 
-class RedisAcademicCache:
-    """Simple Redis-based cache with in-memory fallback."""
+class CacheMetrics:
+    """Collects metrics for cache operations."""
 
-    def __init__(self, redis_url: str = "redis://localhost:6379", ttl: int = 3600) -> None:
-        self.ttl = ttl
+    def __init__(self) -> None:
+        self.hits = 0
+        self.misses = 0
+        self.errors = 0
+
+    def record_hit(self) -> None:
+        self.hits += 1
+
+    def record_miss(self) -> None:
+        self.misses += 1
+
+    def record_error(self) -> None:
+        self.errors += 1
+
+    def snapshot(self) -> Dict[str, int]:
+        return {
+            "hits": self.hits,
+            "misses": self.misses,
+            "errors": self.errors,
+        }
+
+
+class CacheBackend(ABC):
+    """Abstract backend API used by the cache."""
+
+    @abstractmethod
+    async def get(self, key: str) -> Optional[str]:
+        """Retrieve a cached value."""
+
+    @abstractmethod
+    async def set(self, key: str, value: str, ttl: int) -> None:
+        """Store a value with a given TTL."""
+
+    @abstractmethod
+    async def delete(self, key: str) -> None:
+        """Remove a key from the cache."""
+
+    @abstractmethod
+    def size(self) -> int:
+        """Return approximate cache size."""
+
+
+class LRUMemoryBackend(CacheBackend):
+    """Simple in-memory LRU backend."""
+
+    def __init__(self, capacity: int = 128) -> None:
+        self.capacity = capacity
+        self._store: "OrderedDict[str, tuple[str, Optional[float]]]" = OrderedDict()
+
+    async def get(self, key: str) -> Optional[str]:
+        item = self._store.get(key)
+        if not item:
+            return None
+        value, expires_at = item
+        if expires_at and expires_at < time.time():
+            self._store.pop(key, None)
+            return None
+        self._store.move_to_end(key)
+        return value
+
+    async def set(self, key: str, value: str, ttl: int) -> None:
+        expires_at = time.time() + ttl if ttl else None
+        if key in self._store:
+            self._store.pop(key)
+        elif len(self._store) >= self.capacity:
+            self._store.popitem(last=False)
+        self._store[key] = (value, expires_at)
+
+    async def delete(self, key: str) -> None:
+        self._store.pop(key, None)
+
+    def size(self) -> int:
+        return len(self._store)
+
+
+class RedisBackend(CacheBackend):
+    """Redis-based cache backend."""
+
+    def __init__(self, redis_url: str) -> None:
+        import redis.asyncio as redis  # type: ignore
+
+        self._redis = redis.from_url(redis_url, decode_responses=True)
+
+    async def get(self, key: str) -> Optional[str]:
+        return await self._redis.get(key)
+
+    async def set(self, key: str, value: str, ttl: int) -> None:
+        await self._redis.set(key, value, ex=ttl)
+
+    async def delete(self, key: str) -> None:
+        await self._redis.delete(key)
+
+    def size(self) -> int:
+        return 0
+
+
+class MetricsBackend(CacheBackend):
+    """Wraps another backend to collect metrics."""
+
+    def __init__(self, backend: CacheBackend, metrics: CacheMetrics) -> None:
+        self.backend = backend
+        self.metrics = metrics
+
+    async def get(self, key: str) -> Optional[str]:
         try:
-            import redis.asyncio as redis  # type: ignore
-            self._redis = redis.from_url(redis_url, decode_responses=True)
-            self.enabled = True
+            value = await self.backend.get(key)
         except Exception:
-            # Fallback to in-memory dictionary if redis is unavailable
-            self._store: Dict[str, str] = {}
-            self.enabled = False
+            self.metrics.record_error()
+            value = None
+        if value is None:
+            self.metrics.record_miss()
+        else:
+            self.metrics.record_hit()
+        return value
+
+    async def set(self, key: str, value: str, ttl: int) -> None:
+        try:
+            await self.backend.set(key, value, ttl)
+        except Exception:
+            self.metrics.record_error()
+
+    async def delete(self, key: str) -> None:
+        try:
+            await self.backend.delete(key)
+        except Exception:
+            self.metrics.record_error()
+
+    def size(self) -> int:
+        return self.backend.size()
+
+
+class RedisAcademicCache:
+    """Multi-level cache with optional Redis backend."""
+
+    def __init__(self, redis_url: str = "redis://localhost:6379", ttl: int = 3600, memory_capacity: int = 128) -> None:
+        self.ttl = ttl
+        self.metrics = CacheMetrics()
+        self.memory_backend = MetricsBackend(LRUMemoryBackend(memory_capacity), self.metrics)
+        self.redis_backend: Optional[MetricsBackend]
+        try:
+            self.redis_backend = MetricsBackend(RedisBackend(redis_url), self.metrics)
+        except Exception:
+            self.redis_backend = None
 
     def generate_cache_key(self, source: str, query: str, filters: Optional[Dict[str, Any]] = None) -> str:
         filters = filters or {}
@@ -25,27 +162,52 @@ class RedisAcademicCache:
         return f"academic:{source}:{query_hash}:{filter_hash}"
 
     async def get_cached_search(self, key: str) -> Optional[Dict[str, Any]]:
-        if self.enabled:
-            value = await self._redis.get(key)
-            if value:
+        value = await self.memory_backend.get(key)
+        if value is not None:
+            return json.loads(value)
+        if self.redis_backend:
+            value = await self.redis_backend.get(key)
+            if value is not None:
+                await self.memory_backend.set(key, value, self.ttl)
                 return json.loads(value)
-            return None
-        # memory fallback
-        value = self._store.get(key)
-        return json.loads(value) if value else None
+        return None
 
     async def cache_search_result(self, key: str, result: Dict[str, Any], ttl: Optional[int] = None) -> None:
         ttl = ttl or self.ttl
         data = json.dumps(result)
-        if self.enabled:
-            await self._redis.set(key, data, ex=ttl)
-        else:
-            self._store[key] = data
-            # naive in-memory TTL handling
-            asyncio.get_event_loop().call_later(ttl, lambda: self._store.pop(key, None))
+        await self.memory_backend.set(key, data, ttl)
+        if self.redis_backend:
+            await self.redis_backend.set(key, data, ttl)
 
     async def invalidate(self, key: str) -> None:
-        if self.enabled:
-            await self._redis.delete(key)
-        else:
-            self._store.pop(key, None)
+        await self.memory_backend.delete(key)
+        if self.redis_backend:
+            await self.redis_backend.delete(key)
+
+    def memory_usage(self) -> int:
+        """Approximate in-memory cache size."""
+        return self.memory_backend.size()
+
+    async def warm_cache(self, entries: Dict[str, Dict[str, Any]], ttl: Optional[int] = None) -> None:
+        """Pre-populate the cache with common queries."""
+        for key, value in entries.items():
+            await self.cache_search_result(key, value, ttl=ttl)
+
+
+def cache_decorator(cache: RedisAcademicCache, source: str):
+    """Decorator to transparently cache async search methods."""
+
+    def wrapper(func):
+        async def inner(query: str, *args: Any, **kwargs: Any):
+            filters = kwargs.get("filters")
+            key = cache.generate_cache_key(source, query, filters)
+            cached = await cache.get_cached_search(key)
+            if cached is not None:
+                return cached
+            result = await func(query, *args, **kwargs)
+            await cache.cache_search_result(key, result)
+            return result
+
+        return inner
+
+    return wrapper

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -17,3 +17,26 @@ def test_cache_roundtrip():
         assert expired is None
 
     asyncio.run(run())
+
+
+def test_cache_metrics_and_lru():
+    async def run():
+        cache = RedisAcademicCache(memory_capacity=1)
+        key1 = cache.generate_cache_key("openalex", "q1", {})
+        await cache.cache_search_result(key1, {"num": 1})
+
+        # hit should increase metrics.hits
+        assert await cache.get_cached_search(key1) == {"num": 1}
+
+        key2 = cache.generate_cache_key("openalex", "q2", {})
+        # miss increments metrics.misses
+        assert await cache.get_cached_search(key2) is None
+
+        metrics = cache.metrics.snapshot()
+        assert metrics["hits"] == 1
+        assert metrics["misses"] >= 1
+
+        # storing second key should evict the first due to LRU capacity=1
+        await cache.cache_search_result(key2, {"num": 2})
+        assert await cache.get_cached_search(key1) is None
+    asyncio.run(run())

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -12,8 +12,10 @@ def test_retriever_caches_result():
         result1 = await agent.search("quantum physics")
         assert result1.source == "openalex"
 
-        # second call should hit cache
+        # second call should hit cache and metrics should report a hit
         result2 = await agent.search("quantum physics")
         assert result2.results == result1.results
+        metrics = cache.metrics.snapshot()
+        assert metrics["hits"] >= 1
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- add CacheBackend base class and MetricsBackend wrapper
- implement RedisBackend and LRUMemoryBackend
- refactor RedisAcademicCache to use strategy pattern and metrics wrapper

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ff16f684832284b71d1268e02565