### PR TITLE
Implement Redis caching and hybrid academic retriever

### DIFF
--- a/knowledge_storm/services/cache_service.py
+++ b/knowledge_storm/services/cache_service.py
@@ -1,0 +1,48 @@
+import json
+from typing import Any, Optional
+
+try:
+    import redis.asyncio as redis  # type: ignore
+except Exception:  # pragma: no cover - optional
+    redis = None
+
+
+class CacheService:
+    """Simple async cache service using Redis if available."""
+
+    def __init__(self, url: str = "redis://localhost:6379/0", ttl: int = 3600) -> None:
+        self.ttl = ttl
+        self._local_cache: dict[str, Any] = {}
+        self.redis: Optional["redis.Redis"] = None
+        if redis is not None:
+            try:
+                self.redis = redis.from_url(url)
+            except Exception:
+                self.redis = None
+
+    async def get(self, key: str) -> Any:
+        if self.redis is not None:
+            try:
+                value = await self.redis.get(key)
+                if value is not None:
+                    return json.loads(value)
+            except Exception:
+                pass
+        return self._local_cache.get(key)
+
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        ttl = ttl or self.ttl
+        if self.redis is not None:
+            try:
+                await self.redis.set(key, json.dumps(value), ex=ttl)
+                return
+            except Exception:
+                pass
+        self._local_cache[key] = value
+
+    async def close(self) -> None:
+        if self.redis is not None:
+            try:
+                await self.redis.close()
+            except Exception:
+                pass

--- a/test_specialized_agents.py
+++ b/test_specialized_agents.py
@@ -6,8 +6,10 @@ from models.agent import (
     CriticAgent,
     CitationVerifierAgent,
     WriterAgent,
+    AcademicRetrieverAgent,
 )
 from knowledge_storm.services.academic_source_service import AcademicSourceService
+from knowledge_storm.services.cache_service import CacheService
 
 
 async def _run(coro):
@@ -43,3 +45,56 @@ def test_writer_agent_citation_formatting():
     agent.update_state("references", [{"author": "Doe", "publication_year": 2020, "title": "Paper", "doi": "10.1"}])
     text = asyncio.run(agent.execute_task("Topic"))
     assert "Doe" in text
+
+
+def test_cache_service():
+    cache = CacheService(ttl=10)
+    asyncio.run(cache.set("k", {"v": 1}))
+    result = asyncio.run(cache.get("k"))
+    assert result == {"v": 1}
+
+
+def test_academic_retriever_agent_with_fallback():
+    service = AcademicSourceService(cache=CacheService())
+
+    class DummyRM:
+        def forward(self, q):
+            return [{"title": "F"}]
+
+    agent = AcademicRetrieverAgent("r", "Retriever", service=service, fallback_rm=DummyRM())
+    with patch.object(service, "search_combined", new=AsyncMock(return_value=[])):
+        results = asyncio.run(agent.execute_task("topic"))
+        assert results == [{"title": "F"}]
+
+
+def test_academic_source_service_caching():
+    cache = CacheService()
+    service = AcademicSourceService(cache=cache)
+    class MockContext:
+        async def __aenter__(self):
+            return mock_resp
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    class MockSession:
+        def __init__(self):
+            self.get_call_count = 0
+
+        def get(self, *args, **kwargs):
+            self.get_call_count += 1
+            return MockContext()
+
+    mock_resp = AsyncMock()
+    mock_resp.json.return_value = {"results": [1]}
+    mock_session = MockSession()
+    from types import SimpleNamespace
+
+    aiohttp_mock = SimpleNamespace(ClientSession=lambda: mock_session)
+    with patch(
+        "knowledge_storm.services.academic_source_service.aiohttp",
+        aiohttp_mock,
+    ):
+        asyncio.run(service.search_openalex("q"))
+        asyncio.run(service.search_openalex("q"))
+        assert mock_session.get_call_count == 1


### PR DESCRIPTION
## Summary
- add `CacheService` providing optional Redis caching
- enhance `AcademicSourceService` with caching, connection pooling and cache warming
- introduce `AcademicRetrieverAgent` with fallback retrieval
- test caching and new retriever functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642a4913008322bdbe94e6bfebaf13