### PR TITLE
Implement caching utilities and improve retriever service

### DIFF
--- a/knowledge_storm/services/academic_source_service.py
+++ b/knowledge_storm/services/academic_source_service.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
 from typing import Any, Dict, List, Optional
 from urllib import parse, request
+
+from .cache_service import CacheService
+from .utils import CacheKeyBuilder, ConnectionManager, CircuitBreaker
 
 try:
     import aiohttp  # type: ignore
@@ -22,8 +27,28 @@ class AcademicSourceService:
     OPENALEX_URL = "https://api.openalex.org/works"
     CROSSREF_URL = "https://api.crossref.org/works"
 
-    def __init__(self) -> None:
-        pass
+    def __init__(
+        self,
+        cache: CacheService | None = None,
+        ttl: int = 3600,
+        conn_manager: ConnectionManager | None = None,
+        key_builder: CacheKeyBuilder | None = None,
+        breaker: CircuitBreaker | None = None,
+    ) -> None:
+        self.cache = cache or CacheService(ttl=ttl)
+        self.ttl = ttl
+        self.conn_manager = conn_manager or ConnectionManager()
+        self.key_builder = key_builder or CacheKeyBuilder()
+        self.breaker = breaker or CircuitBreaker()
+
+    async def close(self) -> None:
+        await self.conn_manager.close()
+
+    async def __aenter__(self) -> "AcademicSourceService":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
 
     async def search_openalex(self, query: str, limit: int = DEFAULT_LIMIT) -> List[Dict[str, Any]]:
         params = {"search": query, "per-page": limit}
@@ -45,13 +70,36 @@ class AcademicSourceService:
     async def get_publication_metadata(self, doi: str) -> Dict[str, Any]:
         return await self.resolve_doi(doi)
 
+    async def search_combined(self, query: str, limit: int = DEFAULT_LIMIT) -> List[Dict[str, Any]]:
+        openalex_coro = self.search_openalex(query, limit)
+        crossref_coro = self.search_crossref(query, limit)
+        openalex, crossref = await asyncio.gather(openalex_coro, crossref_coro)
+        return openalex + crossref
+
+    async def warm_cache(self, queries: List[str], limit: int = DEFAULT_LIMIT) -> None:
+        for q in queries:
+            await self.search_combined(q, limit)
+
     async def _fetch_json(self, url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        cache_key = self.key_builder.build_key(url, params)
+
+        cached = await self.cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        if not self.breaker.should_allow_request():
+            raise RuntimeError("Circuit breaker open")
+
         try:
-            if aiohttp:
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(url, params=params, timeout=10) as resp:
-                        resp.raise_for_status()
-                        return await resp.json()
+            try:
+                session = await self.conn_manager.get_session()
+            except RuntimeError:
+                session = None
+
+            if session is not None:
+                async with session.get(url, params=params, timeout=10) as resp:
+                    resp.raise_for_status()
+                    data = await resp.json()
             else:
                 def _sync() -> Dict[str, Any]:
                     full_url = url
@@ -60,9 +108,16 @@ class AcademicSourceService:
                     with request.urlopen(full_url) as resp:
                         return json.load(resp)
 
-                return await asyncio.to_thread(_sync)
+                data = await asyncio.to_thread(_sync)
+
+            await self.cache.set(cache_key, data, self.ttl)
+            self.breaker.record_success()
+            return data
         except Exception:  # pragma: no cover - network errors
+            self.breaker.record_failure()
             logger.exception("Failed request to %s", url)
+            if not self.breaker.should_allow_request():
+                raise
             return {}
 
 

--- a/knowledge_storm/services/cache_service.py
+++ b/knowledge_storm/services/cache_service.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+try:
+    import redis.asyncio as redis  # type: ignore
+    from redis.exceptions import RedisError  # type: ignore
+except Exception:  # pragma: no cover - optional
+    redis = None
+    RedisError = Exception
+
+
+class CacheService:
+    """Simple async cache service using Redis if available."""
+
+    def __init__(self, url: str = "redis://localhost:6379/0", ttl: int = 3600) -> None:
+        self.ttl = ttl
+        self._local_cache: dict[str, Any] = {}
+        self.redis: Optional["redis.Redis"] = None
+        if redis is not None:
+            try:
+                self.redis = redis.from_url(url)
+            except RedisError:
+                self.redis = None
+
+    async def get(self, key: str) -> Any:
+        if self.redis is not None:
+            try:
+                value = await self.redis.get(key)
+                if value is not None:
+                    return json.loads(value)
+            except RedisError:
+                pass
+        return self._local_cache.get(key)
+
+    async def set(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        ttl = ttl or self.ttl
+        if self.redis is not None:
+            try:
+                await self.redis.set(key, json.dumps(value), ex=ttl)
+                return
+            except RedisError:
+                pass
+        self._local_cache[key] = value
+
+    async def close(self) -> None:
+        if self.redis is not None:
+            try:
+                await self.redis.close()
+            except RedisError:
+                pass
+
+    async def __aenter__(self) -> "CacheService":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()

--- a/knowledge_storm/services/utils.py
+++ b/knowledge_storm/services/utils.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from urllib import parse
+
+try:
+    import aiohttp  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    aiohttp = None
+
+
+class CacheKeyBuilder:
+    """Builds cache keys for API requests."""
+
+    def build_key(self, url: str, params: Optional[Dict[str, Any]] = None) -> str:
+        base_key = url
+        if params:
+            sorted_params = sorted(params.items())
+            param_string = parse.urlencode(sorted_params)
+            return f"{base_key}?{param_string}"
+        return base_key
+
+
+class ConnectionManager:
+    """Manages a reusable aiohttp session."""
+
+    def __init__(self) -> None:
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _create_session(self) -> "aiohttp.ClientSession":
+        if aiohttp is None:
+            raise RuntimeError("aiohttp not installed")
+        return aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+
+    async def get_session(self) -> "aiohttp.ClientSession":
+        if self._session is None:
+            self._session = await self._create_session()
+        return self._session
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def __aenter__(self) -> "ConnectionManager":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+
+class CircuitBreaker:
+    """Simple circuit breaker for failing external calls."""
+
+    def __init__(self, failure_threshold: int = 3) -> None:
+        self.failure_count = 0
+        self.failure_threshold = failure_threshold
+
+    def record_success(self) -> None:
+        self.failure_count = 0
+
+    def record_failure(self) -> None:
+        self.failure_count += 1
+
+    def should_allow_request(self) -> bool:
+        return self.failure_count < self.failure_threshold


### PR DESCRIPTION
## Summary
- extract cache key builder, connection manager and circuit breaker utilities
- refactor `AcademicSourceService` to use new utilities and provide async context manager
- update cache service with async context manager and targeted error handling
- adjust tests for new connection management logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642a4913008322bdbe94e6bfebaf13