### PR TITLE
Refactor citation verification classes

### DIFF
--- a/knowledge_storm/services/citation_formatter.py
+++ b/knowledge_storm/services/citation_formatter.py
@@ -1,0 +1,36 @@
+from typing import Any, Dict
+
+
+class CitationFormatter:
+    """Format citation metadata in various styles."""
+
+    def format(self, source: Dict[str, Any], style: str = "APA") -> str:
+        data = self._extract_citation_data(source)
+        return self._format_by_style(data, style.upper())
+
+    def _extract_citation_data(self, source: Dict[str, Any]) -> Dict[str, str]:
+        return {
+            "author": source.get("author", "Anon"),
+            "year": self._get_publication_year(source),
+            "title": source.get("title", ""),
+        }
+
+    def _get_publication_year(self, source: Dict[str, Any]) -> str:
+        return str(source.get("year") or source.get("publication_year", "n.d."))
+
+    def _format_by_style(self, data: Dict[str, str], style: str) -> str:
+        if style == "MLA":
+            return self._format_mla(data)
+        if style == "CHICAGO":
+            return self._format_chicago(data)
+        return self._format_apa(data)
+
+    def _format_mla(self, data: Dict[str, str]) -> str:
+        return f"{data['author']}. \"{data['title']}\" ({data['year']})."
+
+    def _format_chicago(self, data: Dict[str, str]) -> str:
+        return f"{data['author']}. {data['year']}. {data['title']}."
+
+    def _format_apa(self, data: Dict[str, str]) -> str:
+        return f"{data['author']} ({data['year']}). {data['title']}."
+

--- a/knowledge_storm/services/citation_verifier.py
+++ b/knowledge_storm/services/citation_verifier.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from difflib import SequenceMatcher
+from typing import Any, Dict, List, Tuple
+
+from .academic_source_service import AcademicSourceService, SourceQualityScorer
+from .cache_service import CacheService
+from .config import VerificationConfig
+
+logger = logging.getLogger(__name__)
+
+
+
+class CitationVerifier:
+    """Verify textual claims against academic sources."""
+
+    def __init__(self, cache: CacheService | None = None) -> None:
+        self.cache = cache or CacheService()
+        self.source_service = AcademicSourceService(cache=self.cache)
+        self.scorer = SourceQualityScorer()
+
+    def verify_citation(self, claim: str, source: Dict[str, Any]) -> Dict[str, Any]:
+        return asyncio.run(self.verify_citation_async(claim, source))
+
+    async def verify_citation_async(self, claim: str, source: Dict[str, Any]) -> Dict[str, Any]:
+        cache_key = self._build_cache_key(claim, source)
+        cached = await self._get_cached_result(cache_key)
+        if cached is not None:
+            return cached
+        return await self._perform_verification(claim, source, cache_key)
+
+    def _build_cache_key(self, claim: str, source: Dict[str, Any]) -> str:
+        identifier = source.get("doi") or source.get("url", "")
+        return f"{claim}:{identifier}"
+
+    async def _get_cached_result(self, cache_key: str) -> Dict[str, Any] | None:
+        return await self.cache.get(cache_key)
+
+    async def _perform_verification(self, claim: str, source: Dict[str, Any], cache_key: str) -> Dict[str, Any]:
+        text, metadata = await self._extract_source_content(source)
+        result = self._create_verification_result(claim, text, metadata)
+        await self.cache.set(cache_key, result)
+        return result
+
+    async def _extract_source_content(self, source: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+        text = self._get_initial_text(source)
+        metadata = source
+        if self._needs_doi_fetch(text, source):
+            text, metadata = await self._fetch_from_doi(source["doi"])
+        return text, metadata
+
+    def _get_initial_text(self, source: Dict[str, Any]) -> str:
+        return source.get("text") or source.get("abstract", "")
+
+    def _needs_doi_fetch(self, text: str, source: Dict[str, Any]) -> bool:
+        return not text and "doi" in source
+
+    async def _fetch_from_doi(self, doi: str) -> Tuple[str, Dict[str, Any]]:
+        metadata = await self._fetch_metadata(doi)
+        text = metadata.get("abstract", "")
+        return text, metadata
+
+    async def _fetch_metadata(self, doi: str) -> Dict[str, Any]:
+        try:
+            return await self.source_service.get_publication_metadata(doi)
+        except Exception as e:  # pragma: no cover - network errors
+            logger.error("Failed to fetch metadata for DOI %s: %s", doi, e)
+            return {}
+
+    def _create_verification_result(self, claim: str, text: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+        score = self._calculate_verification_score(claim, text)
+        return {
+            "verified": self._is_verified(score),
+            "confidence": score,
+            "quality_metrics": self._assess_source_quality(metadata),
+        }
+
+    def _calculate_verification_score(self, claim: str, source_text: str) -> float:
+        normalized_claim = self._normalize_text(claim)
+        normalized_source = self._normalize_text(source_text)
+        return SequenceMatcher(None, normalized_claim, normalized_source).ratio()
+
+    def _normalize_text(self, text: str) -> str:
+        return text.lower()
+
+    def _assess_source_quality(self, metadata: Dict[str, Any]) -> Dict[str, Any]:
+        if not metadata:
+            return {}
+        return {"score": self.scorer.score_source(metadata)}
+
+    def _is_verified(self, score: float) -> bool:
+        return score > VerificationConfig.VERIFICATION_THRESHOLD
+
+

--- a/knowledge_storm/services/config.py
+++ b/knowledge_storm/services/config.py
@@ -1,0 +1,6 @@
+class VerificationConfig:
+    """Configuration settings for citation verification."""
+
+    VERIFICATION_THRESHOLD = 0.7
+    CACHE_TTL = 3600
+    MAX_RETRIES = 3

--- a/knowledge_storm/services/section_verifier.py
+++ b/knowledge_storm/services/section_verifier.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List
+
+from .citation_verifier import CitationVerifier
+
+logger = logging.getLogger(__name__)
+
+
+class SectionCitationVerifier:
+    """Verify citations referenced within a section."""
+
+    def __init__(self, verifier: CitationVerifier) -> None:
+        self.verifier = verifier
+
+    def verify_section(self, section_text: str, info_list: List[Any]) -> List[Dict[str, Any]]:
+        indices = self._extract_citation_indices(section_text)
+        return self._verify_citations_by_indices(indices, info_list)
+
+    def _extract_citation_indices(self, section_text: str) -> List[int]:
+        indices: List[int] = []
+        for match in re.findall(r"\[[^\]]+\]", section_text):
+            try:
+                indices.append(int(match[1:-1]))
+            except ValueError:  # pragma: no cover - malformed citation
+                logger.warning("Invalid citation format: %s", match)
+        return indices
+
+    def _verify_citations_by_indices(self, indices: List[int], info_list: List[Any]) -> List[Dict[str, Any]]:
+        results = []
+        for idx in indices:
+            result = self._verify_single_citation(idx, info_list)
+            if result:
+                results.append(result)
+        return results
+
+    def _verify_single_citation(self, idx: int, info_list: List[Any]) -> Dict[str, Any] | None:
+        if not (0 < idx <= len(info_list)):
+            return None
+        snippet = self._get_snippet_text(info_list[idx - 1])
+        return self.verifier.verify_citation(snippet, {"text": snippet})
+
+    def _get_snippet_text(self, info_item: Any) -> str:
+        return info_item.snippets[0] if info_item.snippets else ""
+

--- a/test_citation_verification_system.py
+++ b/test_citation_verification_system.py
@@ -1,0 +1,81 @@
+import asyncio
+from types import SimpleNamespace
+
+from knowledge_storm.services.citation_verifier import CitationVerifier
+from knowledge_storm.services.section_verifier import SectionCitationVerifier
+from knowledge_storm.services.citation_formatter import CitationFormatter
+from knowledge_storm.services.cache_service import CacheService
+from knowledge_storm.services.config import VerificationConfig
+
+class DummyConvToSection:
+    def __init__(self, section_verifier=None):
+        self.section_verifier = section_verifier
+        self.write_section = lambda **kw: SimpleNamespace(output="# Heading\nText [1]")
+
+    def forward(self, topic, outline, section, collected_info):
+        text = self.write_section().output
+        if self.section_verifier:
+            self.section_verifier.verify_section(text, collected_info)
+        return SimpleNamespace(section=text)
+
+
+class StormInformation:
+    def __init__(self, uuid, description, snippets, title):
+        self.uuid = uuid
+        self.description = description
+        self.snippets = snippets
+        self.title = title
+
+
+def test_verify_citation_and_caching():
+    cache = CacheService()
+    system = CitationVerifier(cache=cache)
+    claim = "The sky is blue"
+    source = {"text": "The sky is blue and clear."}
+    result1 = asyncio.run(system.verify_citation_async(claim, source))
+    result2 = asyncio.run(system.verify_citation_async(claim, source))
+    assert result1 == result2
+    assert result1["verified"]
+    assert result1["confidence"] > 0.7
+
+
+def test_conv_to_section_triggers_verification(monkeypatch):
+    base_verifier = CitationVerifier(cache=CacheService())
+    verifier = SectionCitationVerifier(base_verifier)
+    called = {}
+
+    def mock_verify(section_text, info_list):
+        called["v"] = True
+        return []
+
+    verifier.verify_section = mock_verify
+    conv = DummyConvToSection(section_verifier=verifier)
+    info = [StormInformation("u", "d", ["Text"], "t")]
+    conv.forward("topic", "", "sec", info)
+    assert called.get("v")
+
+
+def test_citation_data_extraction():
+    system = CitationFormatter()
+    source = {"author": "Smith", "publication_year": 2023, "title": "Test"}
+    data = system._extract_citation_data(source)
+    assert data["author"] == "Smith"
+    assert data["year"] == "2023"
+
+
+def test_cache_key_building():
+    system = CitationVerifier()
+    key = system._build_cache_key("claim", {"doi": "10.1234"})
+    assert "claim:10.1234" == key
+
+
+def test_extract_invalid_citation_indices(caplog):
+    verifier = SectionCitationVerifier(CitationVerifier())
+    with caplog.at_level('WARNING'):
+        indices = verifier._extract_citation_indices("Text [abc]")
+    assert indices == []
+    assert any("Invalid citation format" in m for m in caplog.text.splitlines())
+
+
+def test_threshold_from_config():
+    assert VerificationConfig.VERIFICATION_THRESHOLD == 0.7


### PR DESCRIPTION
## Summary
- split `CitationVerificationSystem` into smaller classes
- introduce `CitationVerifier`, `SectionCitationVerifier`, and `CitationFormatter`
- update article generation to use new verifier structure
- adjust tests for refactored modules
- add configurable verification settings and better validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864444d1e808322a415638a9c2fbe50