### PR TITLE
Add Crossref integration layer

### DIFF
--- a/knowledge_storm/models/__init__.py
+++ b/knowledge_storm/models/__init__.py
@@ -1,0 +1,3 @@
+from .paper import Paper
+
+__all__ = ["Paper"]

--- a/knowledge_storm/models/paper.py
+++ b/knowledge_storm/models/paper.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Paper:
+    """Simple representation of an academic paper."""
+
+    doi: Optional[str] = None
+    title: str = ""
+    authors: List[str] | None = None
+    journal: Optional[str] = None
+    year: Optional[int] = None
+
+    @classmethod
+    def from_crossref_response(cls, crossref_data: Dict[str, Any]) -> "Paper":
+        """Convert Crossref API response to Paper object."""
+        message = crossref_data.get("message", crossref_data)
+        doi = message.get("DOI") or message.get("doi")
+
+        title_field = message.get("title", "")
+        if isinstance(title_field, list):
+            title = title_field[0] if title_field else ""
+        else:
+            title = title_field or ""
+
+        authors: List[str] = []
+        for author in message.get("author", []):
+            parts = [author.get("given", ""), author.get("family", "")]
+            name = " ".join(p for p in parts if p)
+            if name:
+                authors.append(name)
+
+        journal = None
+        container = message.get("container-title")
+        if isinstance(container, list):
+            journal = container[0] if container else None
+        elif isinstance(container, str):
+            journal = container
+
+        year = None
+        issued = message.get("issued")
+        if issued and isinstance(issued, dict):
+            date_parts = issued.get("date-parts")
+            if isinstance(date_parts, list) and date_parts and date_parts[0]:
+                year = date_parts[0][0]
+
+        return cls(doi=doi, title=title, authors=authors or None, journal=journal, year=year)

--- a/knowledge_storm/modules/__init__.py
+++ b/knowledge_storm/modules/__init__.py
@@ -1,0 +1,4 @@
+from .academic_rm import CrossrefRM
+from .multi_agent_knowledge_curation import MultiAgentKnowledgeCurationModule
+
+__all__ = ["CrossrefRM", "MultiAgentKnowledgeCurationModule"]

--- a/knowledge_storm/modules/academic_rm.py
+++ b/knowledge_storm/modules/academic_rm.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Union
+
+import dspy
+
+from ..services.crossref_service import CrossrefService
+from ..services.academic_source_service import SourceQualityScorer
+
+
+class CrossrefRM(dspy.Retrieve):
+    """Retrieve papers from Crossref and rank by quality."""
+
+    def __init__(self, k: int = 3, service: CrossrefService | None = None, scorer: SourceQualityScorer | None = None):
+        super().__init__(k=k)
+        self.service = service or CrossrefService()
+        self.scorer = scorer or SourceQualityScorer()
+        self.usage = 0
+
+    def get_usage_and_reset(self) -> Dict[str, int]:
+        usage = self.usage
+        self.usage = 0
+        return {"CrossrefRM": usage}
+
+    def forward(self, query_or_queries: Union[str, List[str]], exclude_urls: List[str] | None = None) -> List[Dict[str, Any]]:
+        queries = [query_or_queries] if isinstance(query_or_queries, str) else query_or_queries
+        self.usage += len(queries)
+        exclude_urls = exclude_urls or []
+        loop = asyncio.get_event_loop()
+        collected: List[Dict[str, Any]] = []
+        for query in queries:
+            items = loop.run_until_complete(self.service.search_works(query, self.k))
+            for item in items:
+                doi = item.get("DOI")
+                url = f"https://doi.org/{doi}" if doi else ""
+                if url and url in exclude_urls:
+                    continue
+                metadata = item
+                score = self.scorer.score_source(metadata)
+                title = metadata.get("title", [""])
+                if isinstance(title, list):
+                    title = title[0] if title else ""
+                result = {
+                    "url": url,
+                    "title": title,
+                    "description": metadata.get("abstract", ""),
+                    "snippets": [metadata.get("abstract", "")],
+                    "score": score,
+                    "doi": doi,
+                }
+                collected.append(result)
+        collected.sort(key=lambda r: r.get("score", 0), reverse=True)
+        if self.k:
+            return collected[: self.k]
+        return collected

--- a/knowledge_storm/services/crossref_service.py
+++ b/knowledge_storm/services/crossref_service.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Dict, Optional
+from urllib import parse, request
+
+from .cache_service import CacheService
+from .utils import CacheKeyBuilder, ConnectionManager, CircuitBreaker
+
+try:
+    import aiohttp  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    aiohttp = None
+
+logger = logging.getLogger(__name__)
+
+
+class CrossrefService:
+    """Service layer for Crossref API interactions."""
+
+    BASE_URL = "https://api.crossref.org/works"
+    JOURNAL_URL = "https://api.crossref.org/journals"
+
+    def __init__(
+        self,
+        cache: CacheService | None = None,
+        ttl: int = 86400,
+        conn_manager: ConnectionManager | None = None,
+        key_builder: CacheKeyBuilder | None = None,
+        breaker: CircuitBreaker | None = None,
+        rate_limit_interval: float = 3.6,
+    ) -> None:
+        self.cache = cache or CacheService(ttl=ttl)
+        self.ttl = ttl
+        self.conn_manager = conn_manager or ConnectionManager()
+        self.key_builder = key_builder or CacheKeyBuilder()
+        self.breaker = breaker or CircuitBreaker()
+        self._rate_limit = rate_limit_interval
+        self._last_request = 0.0
+        self._lock = asyncio.Lock()
+
+    async def close(self) -> None:
+        await self.conn_manager.close()
+
+    async def __aenter__(self) -> "CrossrefService":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def _wait_rate_limit(self) -> None:
+        async with self._lock:
+            wait = self._rate_limit - (time.time() - self._last_request)
+            if wait > 0:
+                await asyncio.sleep(wait)
+            self._last_request = time.time()
+
+    async def _fetch_json(self, url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        cache_key = self.key_builder.build_key(url, params)
+        cached = await self.cache.get(cache_key)
+        if cached is not None:
+            return cached
+        if not self.breaker.should_allow_request():
+            raise RuntimeError("Circuit breaker open")
+        await self._wait_rate_limit()
+        attempt = 0
+        while True:
+            try:
+                try:
+                    session = await self.conn_manager.get_session()
+                except RuntimeError:
+                    session = None
+                if session is not None:
+                    async with session.get(url, params=params, timeout=10) as resp:
+                        resp.raise_for_status()
+                        data = await resp.json()
+                else:
+                    def _sync() -> Dict[str, Any]:
+                        full_url = url
+                        if params:
+                            full_url += f"?{parse.urlencode(params)}"
+                        with request.urlopen(full_url) as resp:
+                            return json.load(resp)  # type: ignore
+                    import json
+                    data = await asyncio.to_thread(_sync)
+                await self.cache.set(cache_key, data, self.ttl)
+                self.breaker.record_success()
+                return data
+            except Exception as e:  # pragma: no cover - network errors
+                self.breaker.record_failure()
+                logger.exception("Failed request to %s: %s", url, e)
+                attempt += 1
+                if attempt >= 3 or not self.breaker.should_allow_request():
+                    break
+                await asyncio.sleep(2 ** attempt)
+        return {}
+
+    async def search_works(self, query: str, limit: int = 5) -> list[Dict[str, Any]]:
+        params = {"query": query, "rows": limit}
+        data = await self._fetch_json(self.BASE_URL, params)
+        return data.get("message", {}).get("items", [])
+
+    async def get_metadata_by_doi(self, doi: str) -> Dict[str, Any]:
+        data = await self._fetch_json(f"{self.BASE_URL}/{doi}")
+        return data.get("message", {})
+
+    async def validate_citation(self, citation_data: Dict[str, Any]) -> bool:
+        doi = citation_data.get("doi")
+        if not doi:
+            return False
+        metadata = await self.get_metadata_by_doi(doi)
+        return bool(metadata)
+
+    async def get_journal_metadata(self, issn: str) -> Dict[str, Any]:
+        data = await self._fetch_json(f"{self.JOURNAL_URL}/{issn}")
+        return data.get("message", {})

--- a/test_crossref_rm.py
+++ b/test_crossref_rm.py
@@ -1,0 +1,19 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("dspy")
+
+from knowledge_storm.modules.academic_rm import CrossrefRM
+
+
+def test_crossref_rm_ranking():
+    rm = CrossrefRM(k=2)
+    items = [
+        {"DOI": "1", "title": ["A"], "is-referenced-by-count": 5, "issued": {"date-parts": [[2010]]}},
+        {"DOI": "2", "title": ["B"], "is-referenced-by-count": 10, "issued": {"date-parts": [[2020]]}},
+    ]
+    with patch.object(rm.service, "search_works", new=AsyncMock(return_value=items)):
+        results = rm.forward("q")
+        assert results[0]["doi"] == "2"
+        assert results[1]["doi"] == "1"

--- a/test_crossref_service.py
+++ b/test_crossref_service.py
@@ -1,0 +1,29 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from knowledge_storm.services.crossref_service import CrossrefService
+
+
+async def _run(coro):
+    return await coro
+
+
+def test_get_metadata_by_doi():
+    service = CrossrefService()
+    with patch.object(service, "_fetch_json", new=AsyncMock(return_value={"message": {"x": 1}})):
+        result = asyncio.run(service.get_metadata_by_doi("10.1"))
+        assert result == {"x": 1}
+
+
+def test_validate_citation():
+    service = CrossrefService()
+    with patch.object(service, "get_metadata_by_doi", new=AsyncMock(return_value={"title": "T"})):
+        ok = asyncio.run(service.validate_citation({"doi": "10.1"}))
+        assert ok is True
+
+
+def test_get_journal_metadata():
+    service = CrossrefService()
+    with patch.object(service, "_fetch_json", new=AsyncMock(return_value={"message": {"journal": "J"}})):
+        result = asyncio.run(service.get_journal_metadata("1234"))
+        assert result == {"journal": "J"}

--- a/test_paper_crossref.py
+++ b/test_paper_crossref.py
@@ -1,0 +1,19 @@
+from knowledge_storm.models.paper import Paper
+
+
+def test_from_crossref_response():
+    data = {
+        "message": {
+            "DOI": "10.1234/example",
+            "title": ["Sample Paper"],
+            "author": [{"given": "Jane", "family": "Doe"}],
+            "container-title": ["Journal"],
+            "issued": {"date-parts": [[2021]]},
+        }
+    }
+    paper = Paper.from_crossref_response(data)
+    assert paper.doi == "10.1234/example"
+    assert paper.title == "Sample Paper"
+    assert paper.authors == ["Jane Doe"]
+    assert paper.journal == "Journal"
+    assert paper.year == 2021


### PR DESCRIPTION
## Summary
- implement Paper model with Crossref conversion
- add CrossrefService with caching and rate limiting
- implement CrossrefRM retrieval module using quality scoring
- export new module objects
- test CrossrefService, CrossrefRM and Paper conversion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680e6d7d908322942359cbc8af4fe7