### PR TITLE
Add Crossref integration layer

### DIFF
--- a/knowledge_storm/models/__init__.py
+++ b/knowledge_storm/models/__init__.py
@@ -1,0 +1,3 @@
+from .paper import Paper
+
+__all__ = ["Paper"]

--- a/knowledge_storm/models/paper.py
+++ b/knowledge_storm/models/paper.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Paper:
+    """Simple representation of an academic paper."""
+
+    doi: Optional[str] = None
+    title: str = ""
+    authors: List[str] | None = None
+    journal: Optional[str] = None
+    year: Optional[int] = None
+
+    @classmethod
+    def from_crossref_response(cls, crossref_data: Dict[str, Any]) -> "Paper":
+        """Convert Crossref API response to ``Paper``."""
+        message = crossref_data.get("message", crossref_data)
+        return cls(
+            doi=message.get("DOI") or message.get("doi"),
+            title=cls._parse_title(message),
+            authors=cls._parse_authors(message) or None,
+            journal=cls._parse_journal(message),
+            year=cls._parse_year(message),
+        )
+
+    @staticmethod
+    def _parse_title(msg: Dict[str, Any]) -> str:
+        title = msg.get("title", "")
+        if isinstance(title, list):
+            return title[0] if title else ""
+        return title or ""
+
+    @staticmethod
+    def _parse_authors(msg: Dict[str, Any]) -> List[str]:
+        authors: List[str] = []
+        for author in msg.get("author", []):
+            parts = [author.get("given", ""), author.get("family", "")]
+            name = " ".join(p for p in parts if p)
+            if name:
+                authors.append(name)
+        return authors
+
+    @staticmethod
+    def _parse_journal(msg: Dict[str, Any]) -> Optional[str]:
+        container = msg.get("container-title")
+        if isinstance(container, list):
+            return container[0] if container else None
+        if isinstance(container, str):
+            return container
+        return None
+
+    @staticmethod
+    def _parse_year(msg: Dict[str, Any]) -> Optional[int]:
+        issued = msg.get("issued")
+        if isinstance(issued, dict):
+            parts = issued.get("date-parts")
+            if isinstance(parts, list) and parts and parts[0]:
+                return parts[0][0]
+        return None

--- a/knowledge_storm/modules/__init__.py
+++ b/knowledge_storm/modules/__init__.py
@@ -1,0 +1,4 @@
+from .academic_rm import CrossrefRM
+from .multi_agent_knowledge_curation import MultiAgentKnowledgeCurationModule
+
+__all__ = ["CrossrefRM", "MultiAgentKnowledgeCurationModule"]

--- a/knowledge_storm/modules/academic_rm.py
+++ b/knowledge_storm/modules/academic_rm.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Union
+
+import dspy
+
+from ..services.crossref_service import CrossrefService
+from ..services.academic_source_service import SourceQualityScorer
+
+
+class CrossrefRM(dspy.Retrieve):
+    """Retrieve papers from Crossref and rank by quality."""
+
+    def __init__(self, k: int = 3, service: CrossrefService | None = None, scorer: SourceQualityScorer | None = None):
+        super().__init__(k=k)
+        self.service = service or CrossrefService()
+        self.scorer = scorer or SourceQualityScorer()
+        self.usage = 0
+
+    def get_usage_and_reset(self) -> Dict[str, int]:
+        usage = self.usage
+        self.usage = 0
+        return {"CrossrefRM": usage}
+
+    async def _search_all(self, queries: List[str]) -> List[List[Dict[str, Any]]]:
+        tasks = [self.service.search_works(q, self.k) for q in queries]
+        return await asyncio.gather(*tasks)
+
+    def _include(self, doi_url: str, exclude_urls: List[str]) -> bool:
+        return not (doi_url and doi_url in exclude_urls)
+
+    def _normalize_queries(self, qs: Union[str, List[str]]) -> List[str]:
+        return [qs] if isinstance(qs, str) else qs
+
+    def _gather(self, queries: List[str]) -> List[List[Dict[str, Any]]]:
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(self._search_all(queries))
+
+    def _collect(self, results: List[List[Dict[str, Any]]], exclude_urls: List[str]) -> List[Dict[str, Any]]:
+        return [
+            self._build_result(item)
+            for items in results for item in items
+            if self._include(f"https://doi.org/{item.get('DOI')}" if item.get('DOI') else "", exclude_urls)
+        ]
+
+    def _title_from_item(self, item: Dict[str, Any]) -> str:
+        title = item.get("title", "")
+        if isinstance(title, list):
+            return title[0] if title else ""
+        return title or ""
+
+    def _build_result(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        doi = item.get("DOI")
+        return {
+            "url": f"https://doi.org/{doi}" if doi else "",
+            "title": self._title_from_item(item),
+            "description": item.get("abstract", ""),
+            "snippets": [item.get("abstract", "")],
+            "score": self.scorer.score_source(item),
+            "doi": doi,
+        }
+
+    def forward(
+        self, query_or_queries: Union[str, List[str]], exclude_urls: List[str] | None = None
+    ) -> List[Dict[str, Any]]:
+        queries = self._normalize_queries(query_or_queries)
+        self.usage += len(queries)
+        collected = self._collect(self._gather(queries), exclude_urls or [])
+        collected.sort(key=lambda r: r.get("score", 0), reverse=True)
+        return collected[: self.k] if self.k else collected

--- a/knowledge_storm/services/crossref_service.py
+++ b/knowledge_storm/services/crossref_service.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Dict, Optional
+from urllib import parse, request
+
+from dataclasses import dataclass, field
+
+from .cache_service import CacheService
+from .utils import CacheKeyBuilder, ConnectionManager, CircuitBreaker
+
+try:
+    import aiohttp  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    aiohttp = None
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CrossrefConfig:
+    """Configuration for ``CrossrefService``."""
+
+    ttl: int = 86400
+    rate_limit_interval: float = 3.6
+    cache: CacheService | None = None
+    conn_manager: ConnectionManager | None = None
+    key_builder: CacheKeyBuilder | None = None
+    breaker: CircuitBreaker | None = None
+
+
+@dataclass
+class RateLimiter:
+    """Simple async rate limiter."""
+
+    interval: float = 3.6
+    _last_request: float = 0.0
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def wait(self) -> None:
+        async with self._lock:
+            wait = self.interval - (time.time() - self._last_request)
+            if wait > 0:
+                await asyncio.sleep(wait)
+            self._last_request = time.time()
+
+
+@dataclass
+class HttpFetcher:
+    """HTTP helper for Crossref requests."""
+
+    conn_manager: ConnectionManager
+
+    async def fetch(self, url: str, params: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        session = await self._safe_session()
+        if session:
+            return await self._fetch_async(session, url, params)
+        return await self._fetch_sync(url, params)
+
+    async def _safe_session(self) -> Optional["aiohttp.ClientSession"]:
+        try:
+            return await self.conn_manager.get_session()
+        except RuntimeError:
+            return None
+
+    async def _fetch_async(
+        self,
+        session: "aiohttp.ClientSession",
+        url: str,
+        params: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        async with session.get(url, params=params, timeout=10) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+    async def _fetch_sync(self, url: str, params: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        def _sync() -> Dict[str, Any]:
+            full_url = url
+            if params:
+                full_url += f"?{parse.urlencode(params)}"
+            with request.urlopen(full_url) as resp:
+                return json.load(resp)  # type: ignore
+
+        import json
+        return await asyncio.to_thread(_sync)
+
+
+class CrossrefService:
+    """Service layer for Crossref API interactions."""
+
+    BASE_URL = "https://api.crossref.org/works"
+    JOURNAL_URL = "https://api.crossref.org/journals"
+
+    def __init__(self, config: CrossrefConfig | None = None) -> None:
+        config = config or CrossrefConfig()
+        self.cache = config.cache or CacheService(ttl=config.ttl)
+        self.ttl = config.ttl
+        conn_manager = config.conn_manager or ConnectionManager()
+        self.conn_manager = conn_manager
+        self.fetcher = HttpFetcher(conn_manager)
+        self.key_builder = config.key_builder or CacheKeyBuilder()
+        self.breaker = config.breaker or CircuitBreaker()
+        self.rate_limiter = RateLimiter(config.rate_limit_interval)
+
+    async def close(self) -> None:
+        await self.conn_manager.close()
+
+    async def __aenter__(self) -> "CrossrefService":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def _get_cached(self, url: str, params: Optional[Dict[str, Any]]) -> tuple[str, Any]:
+        key = self.key_builder.build_key(url, params)
+        return key, await self.cache.get(key)
+
+    async def _record_success(self, key: str, data: Dict[str, Any]) -> None:
+        await self.cache.set(key, data, self.ttl)
+        self.breaker.record_success()
+
+    async def _handle_error(self, url: str, error: Exception) -> None:
+        self.breaker.record_failure()
+        logger.exception("Failed request to %s: %s", url, error)
+
+    async def _attempt_fetch(self, url: str, params: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        try:
+            return await self.fetcher.fetch(url, params)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # pragma: no cover - network errors
+            await self._handle_error(url, e)
+            return None
+
+    async def _should_retry(self, attempt: int) -> bool:
+        if attempt >= 3 or not self.breaker.should_allow_request():
+            return False
+        await asyncio.sleep(2 ** attempt)
+        return True
+
+    async def _fetch_with_retry(self, url: str, params: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        attempt = 0
+        while True:
+            data = await self._attempt_fetch(url, params)
+            if data is not None:
+                return data
+            attempt += 1
+            if not await self._should_retry(attempt):
+                break
+        return {}
+
+
+    async def _pre_fetch(self) -> None:
+        if not self.breaker.should_allow_request():
+            raise RuntimeError("Circuit breaker open")
+        await self.rate_limiter.wait()
+
+    async def _fetch_json(self, url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        key, cached = await self._get_cached(url, params)
+        if cached is not None:
+            return cached
+        await self._pre_fetch()
+        data = await self._fetch_with_retry(url, params)
+        if data:
+            await self._record_success(key, data)
+        return data
+
+    async def search_works(self, query: str, limit: int = 5) -> list[Dict[str, Any]]:
+        params = {"query": query, "rows": limit}
+        data = await self._fetch_json(self.BASE_URL, params)
+        return data.get("message", {}).get("items", [])
+
+    async def get_metadata_by_doi(self, doi: str) -> Dict[str, Any]:
+        data = await self._fetch_json(f"{self.BASE_URL}/{doi}")
+        return data.get("message", {})
+
+    async def validate_citation(self, citation_data: Dict[str, Any]) -> bool:
+        doi = citation_data.get("doi")
+        if not doi:
+            return False
+        metadata = await self.get_metadata_by_doi(doi)
+        return bool(metadata)
+
+    async def get_journal_metadata(self, issn: str) -> Dict[str, Any]:
+        data = await self._fetch_json(f"{self.JOURNAL_URL}/{issn}")
+        return data.get("message", {})

--- a/test_crossref_rm.py
+++ b/test_crossref_rm.py
@@ -1,0 +1,41 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("dspy")
+
+from knowledge_storm.modules.academic_rm import CrossrefRM
+
+
+def test_crossref_rm_ranking():
+    rm = CrossrefRM(k=2)
+    items = [
+        {"DOI": "1", "title": ["A"], "is-referenced-by-count": 5, "issued": {"date-parts": [[2010]]}},
+        {"DOI": "2", "title": ["B"], "is-referenced-by-count": 10, "issued": {"date-parts": [[2020]]}},
+    ]
+    with patch.object(rm.service, "search_works", new=AsyncMock(return_value=items)):
+        results = rm.forward("q")
+        assert results[0]["doi"] == "2"
+        assert results[1]["doi"] == "1"
+
+
+def test_crossref_rm_multiple_queries():
+    rm = CrossrefRM(k=0)
+    with patch.object(
+        rm.service,
+        "search_works",
+        side_effect=[AsyncMock(return_value=[{"DOI": "1"}])(), AsyncMock(return_value=[{"DOI": "2"}])()],
+    ) as mock:
+        results = rm.forward(["a", "b"])
+        assert mock.call_count == 2
+        dois = {r["doi"] for r in results}
+        assert dois == {"1", "2"}
+
+
+def test_crossref_rm_exclude_url():
+    rm = CrossrefRM(k=5)
+    items = [{"DOI": "1", "title": ["T"], "issued": {"date-parts": [[2020]]}}]
+    with patch.object(rm.service, "search_works", new=AsyncMock(return_value=items)):
+        results = rm.forward("q", exclude_urls=["https://doi.org/1"])
+        assert results == []
+

--- a/test_crossref_service.py
+++ b/test_crossref_service.py
@@ -1,0 +1,98 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge_storm.services.cache_service import CacheService
+
+from knowledge_storm.services.crossref_service import CrossrefService, CrossrefConfig
+
+
+async def _run(coro):
+    return await coro
+
+
+def test_get_metadata_by_doi():
+    service = CrossrefService()
+    with patch.object(service, "_fetch_json", new=AsyncMock(return_value={"message": {"x": 1}})):
+        result = asyncio.run(service.get_metadata_by_doi("10.1"))
+        assert result == {"x": 1}
+
+
+def test_validate_citation():
+    service = CrossrefService()
+    with patch.object(service, "get_metadata_by_doi", new=AsyncMock(return_value={"title": "T"})):
+        ok = asyncio.run(service.validate_citation({"doi": "10.1"}))
+        assert ok is True
+
+
+def test_get_journal_metadata():
+    service = CrossrefService()
+    with patch.object(service, "_fetch_json", new=AsyncMock(return_value={"message": {"journal": "J"}})):
+        result = asyncio.run(service.get_journal_metadata("1234"))
+        assert result == {"journal": "J"}
+
+
+def test_crossref_service_caching():
+    cache = CacheService()
+    service = CrossrefService(CrossrefConfig(cache=cache))
+
+    class MockContext:
+        async def __aenter__(self):
+            return mock_resp
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    class MockSession:
+        def __init__(self):
+            self.get_call_count = 0
+
+        def get(self, *args, **kwargs):
+            self.get_call_count += 1
+            return MockContext()
+
+    mock_resp = AsyncMock()
+    mock_resp.json.return_value = {"message": {"items": [1]}}
+    mock_session = MockSession()
+    aiohttp_mock = SimpleNamespace(
+        ClientSession=lambda timeout=None: mock_session,
+        ClientTimeout=lambda total=None: None,
+    )
+
+    with patch("knowledge_storm.services.utils.aiohttp", aiohttp_mock):
+        asyncio.run(service.search_works("q"))
+        asyncio.run(service.search_works("q"))
+        assert mock_session.get_call_count == 1
+
+
+def test_crossref_service_rate_limit_called():
+    service = CrossrefService()
+    wait_mock = AsyncMock()
+
+    class DummyResp(str):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    with patch.object(service.rate_limiter, "wait", wait_mock), patch.object(
+        service.fetcher.conn_manager,
+        "get_session",
+        AsyncMock(side_effect=RuntimeError()),
+    ), patch(
+        "knowledge_storm.services.crossref_service.request.urlopen",
+        lambda *args, **kwargs: DummyResp("{}"),
+    ):
+        asyncio.run(service.search_works("q"))
+        assert wait_mock.await_count == 1
+
+
+def test_crossref_service_circuit_breaker():
+    service = CrossrefService()
+    with patch.object(service.breaker, "should_allow_request", return_value=False):
+        with pytest.raises(RuntimeError):
+            asyncio.run(service.search_works("q"))
+

--- a/test_paper_crossref.py
+++ b/test_paper_crossref.py
@@ -1,0 +1,19 @@
+from knowledge_storm.models.paper import Paper
+
+
+def test_from_crossref_response():
+    data = {
+        "message": {
+            "DOI": "10.1234/example",
+            "title": ["Sample Paper"],
+            "author": [{"given": "Jane", "family": "Doe"}],
+            "container-title": ["Journal"],
+            "issued": {"date-parts": [[2021]]},
+        }
+    }
+    paper = Paper.from_crossref_response(data)
+    assert paper.doi == "10.1234/example"
+    assert paper.title == "Sample Paper"
+    assert paper.authors == ["Jane Doe"]
+    assert paper.journal == "Journal"
+    assert paper.year == 2021


### PR DESCRIPTION
## Summary
- implement Paper model with Crossref conversion
- add CrossrefService with caching and rate limiting
- implement CrossrefRM retrieval module using quality scoring
- export new module objects
- test CrossrefService, CrossrefRM and Paper conversion
- fix async retrieval and extend testing
- decompose CrossrefService fetch logic and refactor Paper and RM classes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68680e6d7d908322942359cbc8af4fe7