### PR TITLE
Add configurable STORM engine

### DIFF
--- a/knowledge_storm/__init__.py
+++ b/knowledge_storm/__init__.py
@@ -8,9 +8,10 @@ except ModuleNotFoundError:  # pragma: no cover - handled for optional deps
     rm = None
 
 from . import interface  # noqa: F401
+from .enhanced_engine import STORMConfig, EnhancedSTORMEngine
 try:
     from .storm_wiki import utils  # noqa: F401
 except ModuleNotFoundError:  # pragma: no cover
     utils = None
 
-__all__ = ["lm", "rm", "interface", "utils"]
+__all__ = ["lm", "rm", "interface", "utils", "STORMConfig", "EnhancedSTORMEngine"]

--- a/knowledge_storm/enhanced_engine.py
+++ b/knowledge_storm/enhanced_engine.py
@@ -1,0 +1,56 @@
+class STORMConfig:
+    """Configuration settings for running STORM in different modes."""
+
+    VALID_MODES = {"academic", "wikipedia", "hybrid"}
+
+    def __init__(self, mode: str = "hybrid"):
+        self.set_mode(mode)
+
+    def set_mode(self, mode: str) -> None:
+        """Set the engine mode and update feature flags."""
+        if mode not in self.VALID_MODES:
+            raise ValueError(f"Invalid mode: {mode}")
+        self.mode = mode
+        self.academic_sources = mode in ["academic", "hybrid"]
+        self.quality_gates = mode in ["academic", "hybrid"]
+        self.citation_verification = mode == "academic"
+        self.real_time_verification = mode == "academic"
+
+    def as_dict(self) -> dict:
+        return {
+            "mode": self.mode,
+            "academic_sources": self.academic_sources,
+            "quality_gates": self.quality_gates,
+            "citation_verification": self.citation_verification,
+            "real_time_verification": self.real_time_verification,
+        }
+
+
+class EnhancedSTORMEngine:
+    """Unified entry point for STORM functionality with configurable modes."""
+
+    def __init__(self, config: STORMConfig | None = None):
+        self.config = config or STORMConfig()
+        self.setup_components_based_on_mode()
+
+    def setup_components_based_on_mode(self) -> None:
+        """Placeholder for initializing components based on configuration."""
+        # In the lightweight test implementation we simply store the flags.
+        self.components = {
+            "academic": self.config.academic_sources,
+            "quality": self.config.quality_gates,
+        }
+
+    async def original_workflow(self, topic: str, **kwargs):
+        """Stub for the original STORM workflow."""
+        return f"original:{topic}"
+
+    async def academic_workflow(self, topic: str, **kwargs):
+        """Stub for the enhanced academic workflow."""
+        # Reuse original workflow for the test harness.
+        return await self.original_workflow(topic, **kwargs)
+
+    async def generate_article(self, topic: str, **kwargs):
+        if self.config.academic_sources:
+            return await self.academic_workflow(topic, **kwargs)
+        return await self.original_workflow(topic, **kwargs)

--- a/test_enhanced_engine.py
+++ b/test_enhanced_engine.py
@@ -1,0 +1,28 @@
+import asyncio
+from knowledge_storm import STORMConfig, EnhancedSTORMEngine
+
+
+def test_config_modes():
+    cfg = STORMConfig(mode="hybrid")
+    assert cfg.academic_sources
+    assert cfg.quality_gates
+    assert not cfg.citation_verification
+
+    cfg.set_mode("wikipedia")
+    assert not cfg.academic_sources
+    assert not cfg.quality_gates
+
+    cfg.set_mode("academic")
+    assert cfg.citation_verification
+    assert cfg.real_time_verification
+
+
+def test_engine_dispatch():
+    cfg = STORMConfig(mode="wikipedia")
+    engine = EnhancedSTORMEngine(cfg)
+
+    async def run():
+        result = await engine.generate_article("topic")
+        assert result == "original:topic"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add `STORMConfig` and `EnhancedSTORMEngine` with mode handling
- export new classes via package `__init__`
- test config behaviour and engine dispatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686895ce4664832288fd3108378d5648