### PR TITLE
Implement hybrid STORM config and engine

### DIFF
--- a/knowledge_storm/__init__.py
+++ b/knowledge_storm/__init__.py
@@ -8,9 +8,17 @@ except ModuleNotFoundError:  # pragma: no cover - handled for optional deps
     rm = None
 
 from . import interface  # noqa: F401
+from .hybrid_engine import STORMConfig, EnhancedSTORMEngine  # noqa: F401
 try:
     from .storm_wiki import utils  # noqa: F401
 except ModuleNotFoundError:  # pragma: no cover
     utils = None
 
-__all__ = ["lm", "rm", "interface", "utils"]
+__all__ = [
+    "lm",
+    "rm",
+    "interface",
+    "utils",
+    "STORMConfig",
+    "EnhancedSTORMEngine",
+]

--- a/knowledge_storm/hybrid_engine.py
+++ b/knowledge_storm/hybrid_engine.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+class STORMConfig:
+    """Configuration system for STORM modes."""
+
+    VALID_MODES = ("academic", "wikipedia", "hybrid")
+
+    def __init__(self, mode: str | None = None) -> None:
+        self.set_mode(mode or os.getenv("STORM_MODE", "hybrid"))
+
+    def set_mode(self, mode: str) -> None:
+        if mode not in self.VALID_MODES:
+            raise ValueError(f"Invalid mode: {mode}")
+        self.mode = mode
+        self.academic_sources = mode in ("academic", "hybrid")
+        self.quality_gates = mode in ("academic", "hybrid")
+        self.citation_verification = mode == "academic"
+        self.real_time_verification = mode == "academic"
+
+    def switch_mode(self, mode: str) -> None:
+        """Switch to a new configuration mode at runtime."""
+        self.set_mode(mode)
+
+
+@dataclass
+class Article:
+    """Minimal article representation used for the hybrid engine."""
+
+    topic: str
+    content: str = ""
+
+
+class EnhancedSTORMEngine:
+    """Simple engine that routes workflows based on :class:`STORMConfig`."""
+
+    def __init__(self, config: STORMConfig) -> None:
+        self.config = config
+        self.setup_components_based_on_mode()
+
+    def setup_components_based_on_mode(self) -> None:
+        """Placeholder for mode-specific initialization."""
+        # Real implementation would configure caching, verification, etc.
+        pass
+
+    async def academic_workflow(self, topic: str, **kwargs) -> Article:
+        """Stub for the academic generation workflow."""
+        return Article(topic=topic, content=f"Academic article about {topic}")
+
+    async def original_workflow(self, topic: str, **kwargs) -> Article:
+        """Stub for the original STORM workflow."""
+        return Article(topic=topic, content=f"Wikipedia style article about {topic}")
+
+    async def generate_article(self, topic: str, **kwargs) -> Article:
+        """Unified entry point selecting the workflow based on configuration."""
+        if self.config.academic_sources:
+            return await self.academic_workflow(topic, **kwargs)
+        return await self.original_workflow(topic, **kwargs)

--- a/test_hybrid_engine.py
+++ b/test_hybrid_engine.py
@@ -1,0 +1,36 @@
+import asyncio
+from knowledge_storm.hybrid_engine import STORMConfig, EnhancedSTORMEngine
+
+
+def test_config_modes():
+    cfg = STORMConfig()
+    assert cfg.mode == "hybrid"
+    assert cfg.academic_sources
+    assert cfg.quality_gates
+    assert not cfg.citation_verification
+
+    cfg.switch_mode("wikipedia")
+    assert cfg.mode == "wikipedia"
+    assert not cfg.academic_sources
+
+    cfg.switch_mode("academic")
+    assert cfg.citation_verification
+
+
+def test_engine_routing(monkeypatch):
+    cfg = STORMConfig("academic")
+    engine = EnhancedSTORMEngine(cfg)
+
+    async def academic(topic, **kw):
+        return "A"
+
+    async def original(topic, **kw):
+        return "O"
+
+    monkeypatch.setattr(engine, "academic_workflow", academic)
+    monkeypatch.setattr(engine, "original_workflow", original)
+
+    assert asyncio.run(engine.generate_article("t")) == "A"
+
+    cfg.switch_mode("wikipedia")
+    assert asyncio.run(engine.generate_article("t")) == "O"


### PR DESCRIPTION
## Summary
- expose STORMConfig and EnhancedSTORMEngine in package
- add STORMConfig with runtime mode switching
- create minimal EnhancedSTORMEngine to route workflows
- test configuration logic and engine routing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686895ce4664832288fd3108378d5648