### PR TITLE
Add config and engine skeleton for STORM modes

### DIFF
--- a/knowledge_storm/__init__.py
+++ b/knowledge_storm/__init__.py
@@ -8,9 +8,18 @@ except ModuleNotFoundError:  # pragma: no cover - handled for optional deps
     rm = None
 
 from . import interface  # noqa: F401
+from .storm_config import STORMConfig  # noqa: F401
+from .enhanced_engine import EnhancedSTORMEngine  # noqa: F401
 try:
     from .storm_wiki import utils  # noqa: F401
 except ModuleNotFoundError:  # pragma: no cover
     utils = None
 
-__all__ = ["lm", "rm", "interface", "utils"]
+__all__ = [
+    "lm",
+    "rm",
+    "interface",
+    "utils",
+    "STORMConfig",
+    "EnhancedSTORMEngine",
+]

--- a/knowledge_storm/enhanced_engine.py
+++ b/knowledge_storm/enhanced_engine.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .storm_config import STORMConfig
+from .interface import Article
+
+
+class EnhancedSTORMEngine:
+    """Unified entry point for STORM with configurable modes."""
+
+    def __init__(self, config: STORMConfig, runner: Any) -> None:
+        self.config = config
+        self.runner = runner
+        self.setup_components_based_on_mode()
+
+    def setup_components_based_on_mode(self) -> None:
+        """Setup components based on the selected mode."""
+        # Placeholder for future customization based on mode
+        pass
+
+    async def academic_workflow(self, topic: str, **kwargs: Any) -> Article | None:
+        await self.runner.run(topic=topic, **kwargs)
+        return None
+
+    async def original_workflow(self, topic: str, **kwargs: Any) -> Article | None:
+        await self.runner.run(topic=topic, **kwargs)
+        return None
+
+    async def generate_article(self, topic: str, **kwargs: Any) -> Article | None:
+        if self.config.academic_sources:
+            return await self.academic_workflow(topic, **kwargs)
+        return await self.original_workflow(topic, **kwargs)

--- a/knowledge_storm/storm_config.py
+++ b/knowledge_storm/storm_config.py
@@ -1,0 +1,10 @@
+class STORMConfig:
+    """Configuration for STORM behavior modes."""
+
+    def __init__(self, mode: str = "hybrid") -> None:
+        self.mode = mode
+        self.academic_sources = mode in ["academic", "hybrid"]
+        self.quality_gates = mode in ["academic", "hybrid"]
+        self.citation_verification = mode == "academic"
+        self.real_time_verification = mode == "academic"
+

--- a/test_enhanced_engine.py
+++ b/test_enhanced_engine.py
@@ -1,0 +1,48 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+from knowledge_storm import STORMConfig, EnhancedSTORMEngine
+
+
+class DummyRunner:
+    async def run(self, *args, **kwargs):
+        pass
+
+
+def test_storm_config_modes():
+    cfg = STORMConfig(mode="academic")
+    assert cfg.academic_sources
+    assert cfg.quality_gates
+    assert cfg.citation_verification
+    assert cfg.real_time_verification
+
+    cfg = STORMConfig(mode="wikipedia")
+    assert not cfg.academic_sources
+    assert not cfg.citation_verification
+
+
+def test_engine_uses_correct_workflow(monkeypatch):
+    cfg = STORMConfig(mode="academic")
+    runner = DummyRunner()
+    engine = EnhancedSTORMEngine(cfg, runner)
+
+    called = {}
+
+    async def academic(*a, **k):
+        called["academic"] = True
+
+    async def original(*a, **k):
+        called["original"] = True
+
+    monkeypatch.setattr(engine, "academic_workflow", academic)
+    monkeypatch.setattr(engine, "original_workflow", original)
+
+    asyncio.run(engine.generate_article("topic"))
+    assert called.get("academic")
+    called.clear()
+
+    engine.config = STORMConfig(mode="wikipedia")
+    asyncio.run(engine.generate_article("topic"))
+    assert called.get("original")
+
+


### PR DESCRIPTION
## Summary
- expose `STORMConfig` for selecting operating modes
- add `EnhancedSTORMEngine` stub which delegates to existing runner
- export the new classes from package init
- test the config and engine routing logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686895ce4664832288fd3108378d5648