### PR TITLE
Implement hybrid config validation and engine refactor

### DIFF
--- a/knowledge_storm/__init__.py
+++ b/knowledge_storm/__init__.py
@@ -8,9 +8,20 @@ except ModuleNotFoundError:  # pragma: no cover - handled for optional deps
     rm = None
 
 from . import interface  # noqa: F401
+from .storm_config import STORMConfig  # noqa: F401
+from .hybrid_engine import EnhancedSTORMEngine  # noqa: F401
+from .exceptions import ServiceUnavailableError  # noqa: F401
 try:
     from .storm_wiki import utils  # noqa: F401
 except ModuleNotFoundError:  # pragma: no cover
     utils = None
 
-__all__ = ["lm", "rm", "interface", "utils"]
+__all__ = [
+    "lm",
+    "rm",
+    "interface",
+    "utils",
+    "STORMConfig",
+    "EnhancedSTORMEngine",
+    "ServiceUnavailableError",
+]

--- a/knowledge_storm/config_persistence.py
+++ b/knowledge_storm/config_persistence.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+from typing import Protocol
+
+from .storm_config import STORMConfig
+
+
+class ConfigPersister(Protocol):
+    def save_config(self, config: STORMConfig, path: Path) -> None:
+        ...
+
+    def load_config(self, path: Path) -> STORMConfig:
+        ...
+
+
+class JSONConfigPersister:
+    def save_config(self, config: STORMConfig, path: Path) -> None:
+        config_data = {
+            "mode": config.mode,
+            "academic_sources": config.academic_sources,
+            "quality_gates": config.quality_gates,
+            "citation_verification": config.citation_verification,
+            "real_time_verification": config.real_time_verification,
+        }
+        with path.open("w") as f:
+            json.dump(config_data, f, indent=2)
+
+    def load_config(self, path: Path) -> STORMConfig:
+        with path.open("r") as f:
+            config_data = json.load(f)
+        return STORMConfig(mode=config_data["mode"])
+

--- a/knowledge_storm/config_validators.py
+++ b/knowledge_storm/config_validators.py
@@ -1,0 +1,25 @@
+from enum import Enum
+from typing import Protocol
+
+
+class STORMMode(Enum):
+    ACADEMIC = "academic"
+    WIKIPEDIA = "wikipedia"
+    HYBRID = "hybrid"
+
+
+class ConfigValidator(Protocol):
+    def validate_mode(self, mode: str) -> STORMMode:
+        ...
+
+
+class StrictConfigValidator:
+    def validate_mode(self, mode: str) -> STORMMode:
+        try:
+            return STORMMode(mode)
+        except ValueError:
+            valid_modes = [m.value for m in STORMMode]
+            raise ValueError(
+                f"Invalid mode '{mode}'. Valid modes: {valid_modes}"
+            )
+

--- a/knowledge_storm/environment_config.py
+++ b/knowledge_storm/environment_config.py
@@ -1,0 +1,31 @@
+import os
+from typing import Protocol
+
+from .storm_config import STORMConfig
+
+
+class EnvironmentReader(Protocol):
+    def get_storm_mode(self) -> str | None:
+        ...
+
+
+class ProductionEnvironmentReader:
+    def get_storm_mode(self) -> str | None:
+        return os.getenv("STORM_MODE")
+
+
+class TestEnvironmentReader:
+    def __init__(self, mode: str | None = None) -> None:
+        self._mode = mode
+
+    def get_storm_mode(self) -> str | None:
+        return self._mode
+
+
+def create_config_from_environment(
+    env_reader: EnvironmentReader | None = None,
+) -> STORMConfig:
+    reader = env_reader or ProductionEnvironmentReader()
+    mode = reader.get_storm_mode() or "hybrid"
+    return STORMConfig(mode=mode)
+

--- a/knowledge_storm/exceptions.py
+++ b/knowledge_storm/exceptions.py
@@ -1,0 +1,3 @@
+class ServiceUnavailableError(Exception):
+    """Raised when an external service is unavailable."""
+

--- a/knowledge_storm/hybrid_engine.py
+++ b/knowledge_storm/hybrid_engine.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Protocol, Any
+from dataclasses import dataclass
+import logging
+
+from .storm_config import STORMConfig
+from .exceptions import ServiceUnavailableError
+
+logger = logging.getLogger(__name__)
+
+
+class WorkflowRunner(Protocol):
+    async def run_academic_workflow(self, topic: str, **kwargs) -> Article:
+        ...
+
+    async def run_original_workflow(self, topic: str, **kwargs) -> Article:
+        ...
+
+
+@dataclass(frozen=True)
+class Article:
+    topic: str
+    content: str = ""
+    metadata: dict[str, Any] | None = None
+
+
+class WorkflowSelector:
+    def __init__(self, config: STORMConfig):
+        self._config = config
+
+    def should_use_academic_workflow(self) -> bool:
+        return self._config.academic_sources
+
+    def should_use_quality_gates(self) -> bool:
+        return self._config.quality_gates
+
+    def should_verify_citations(self) -> bool:
+        return self._config.citation_verification
+
+
+class EnhancedSTORMEngine:
+    def __init__(self, config: STORMConfig,
+                 workflow_runner: WorkflowRunner | None = None) -> None:
+        self._config = config
+        self._workflow_selector = WorkflowSelector(config)
+        self._workflow_runner = workflow_runner or DefaultWorkflowRunner()
+        self._setup_components()
+
+    def _setup_components(self) -> None:
+        # Placeholder - would initialize caching, verification, etc.
+        pass
+
+    async def generate_article(self, topic: str, **kwargs) -> Article:
+        if self._workflow_selector.should_use_academic_workflow():
+            return await self._generate_academic_article(topic, **kwargs)
+        return await self._generate_standard_article(topic, **kwargs)
+
+    async def _generate_academic_article(self, topic: str, **kwargs) -> Article:
+        try:
+            article = await self._workflow_runner.run_academic_workflow(topic, **kwargs)
+        except (ConnectionError, TimeoutError, ServiceUnavailableError) as e:
+            logger.warning(
+                f"Academic workflow failed: {e}, falling back to standard"
+            )
+            return await self._generate_standard_article(topic, **kwargs)
+        if self._workflow_selector.should_verify_citations():
+            return await self._verify_and_enhance(article)
+        return article
+
+    async def _generate_standard_article(self, topic: str, **kwargs) -> Article:
+        return await self._workflow_runner.run_original_workflow(topic, **kwargs)
+
+    async def _verify_and_enhance(self, article: Article) -> Article:
+        # Placeholder for citation verification
+        return article
+
+
+class DefaultWorkflowRunner:
+    async def run_academic_workflow(self, topic: str, **kwargs) -> Article:
+        return Article(
+            topic=topic,
+            content=f"Academic article about {topic}",
+            metadata={"type": "academic", "verified": True},
+        )
+
+    async def run_original_workflow(self, topic: str, **kwargs) -> Article:
+        return Article(
+            topic=topic,
+            content=f"Wikipedia style article about {topic}",
+            metadata={"type": "wikipedia"},
+        )
+

--- a/knowledge_storm/storm_config.py
+++ b/knowledge_storm/storm_config.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Callable
+import threading
+
+from .config_validators import STORMMode, ConfigValidator, StrictConfigValidator
+
+
+class STORMConfig:
+    def __init__(self, mode: str | STORMMode = STORMMode.HYBRID,
+                 validator: ConfigValidator | None = None) -> None:
+        self._lock = threading.RLock()
+        self._validator = validator or StrictConfigValidator()
+        self._mode_handlers = self._build_mode_handlers()
+        self.set_mode(mode)
+
+    def _build_mode_handlers(self) -> dict[STORMMode, Callable[[], None]]:
+        return {
+            STORMMode.ACADEMIC: self._configure_academic_mode,
+            STORMMode.WIKIPEDIA: self._configure_wikipedia_mode,
+            STORMMode.HYBRID: self._configure_hybrid_mode,
+        }
+
+    def set_mode(self, mode: str | STORMMode) -> None:
+        if isinstance(mode, str):
+            mode = self._validator.validate_mode(mode)
+        self._current_mode = mode
+        self._mode_handlers[mode]()
+
+    def switch_mode(self, mode: str | STORMMode) -> None:
+        with self._lock:
+            self.set_mode(mode)
+
+    def _configure_academic_mode(self) -> None:
+        self.academic_sources = True
+        self.quality_gates = True
+        self.citation_verification = True
+        self.real_time_verification = True
+
+    def _configure_wikipedia_mode(self) -> None:
+        self.academic_sources = False
+        self.quality_gates = False
+        self.citation_verification = False
+        self.real_time_verification = False
+
+    def _configure_hybrid_mode(self) -> None:
+        self.academic_sources = True
+        self.quality_gates = True
+        self.citation_verification = False
+        self.real_time_verification = False
+
+    @property
+    def mode(self) -> str:
+        with self._lock:
+            return self._current_mode.value
+

--- a/test_config_validation.py
+++ b/test_config_validation.py
@@ -1,0 +1,104 @@
+import asyncio
+import pytest
+
+from knowledge_storm.config_validators import (
+    STORMMode, StrictConfigValidator,
+)
+from knowledge_storm.storm_config import STORMConfig
+from knowledge_storm.environment_config import (
+    TestEnvironmentReader as EnvReader,
+    create_config_from_environment,
+)
+
+
+class TestConfigValidation:
+    def test_valid_modes_accepted(self):
+        validator = StrictConfigValidator()
+        assert validator.validate_mode("academic") == STORMMode.ACADEMIC
+        assert validator.validate_mode("wikipedia") == STORMMode.WIKIPEDIA
+        assert validator.validate_mode("hybrid") == STORMMode.HYBRID
+
+    def test_invalid_mode_raises_detailed_error(self):
+        validator = StrictConfigValidator()
+        with pytest.raises(ValueError, match="Invalid mode 'invalid'.*academic.*wikipedia.*hybrid"):
+            validator.validate_mode("invalid")
+
+    def test_empty_mode_raises_error(self):
+        validator = StrictConfigValidator()
+        with pytest.raises(ValueError):
+            validator.validate_mode("")
+
+    def test_none_mode_raises_error(self):
+        validator = StrictConfigValidator()
+        with pytest.raises(ValueError):
+            validator.validate_mode(None)  # type: ignore[arg-type]
+
+
+class TestSTORMConfig:
+    def test_string_mode_initialization(self):
+        config = STORMConfig("academic")
+        assert config.mode == "academic"
+        assert config.citation_verification
+
+    def test_enum_mode_initialization(self):
+        config = STORMConfig(STORMMode.WIKIPEDIA)
+        assert config.mode == "wikipedia"
+        assert not config.academic_sources
+
+    def test_mode_switching_updates_all_flags(self):
+        config = STORMConfig("wikipedia")
+        assert not config.academic_sources
+
+        config.switch_mode("academic")
+        assert config.academic_sources
+        assert config.citation_verification
+
+    def test_invalid_mode_switch_preserves_state(self):
+        config = STORMConfig("academic")
+        original_mode = config.mode
+
+        with pytest.raises(ValueError):
+            config.switch_mode("invalid")
+
+        assert config.mode == original_mode
+        assert config.citation_verification  # State preserved
+
+
+class TestEnvironmentConfiguration:
+    def test_environment_mode_override(self):
+        reader = EnvReader("academic")
+        config = create_config_from_environment(reader)
+        assert config.mode == "academic"
+
+    def test_missing_environment_defaults_hybrid(self):
+        reader = EnvReader(None)
+        config = create_config_from_environment(reader)
+        assert config.mode == "hybrid"
+
+    def test_invalid_environment_mode_raises_error(self):
+        reader = EnvReader("invalid")
+        with pytest.raises(ValueError):
+            create_config_from_environment(reader)
+
+
+class TestConcurrentAccess:
+    def test_concurrent_mode_switches(self):
+        config = STORMConfig("hybrid")
+
+        async def switch_to_academic():
+            config.switch_mode("academic")
+            await asyncio.sleep(0.01)
+            assert config.mode == "academic"
+
+        async def switch_to_wikipedia():
+            config.switch_mode("wikipedia")
+            await asyncio.sleep(0.01)
+            assert config.mode == "wikipedia"
+
+        async def run():
+            tasks = [switch_to_academic(), switch_to_wikipedia()]
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        asyncio.run(run())
+
+

--- a/test_hybrid_engine.py
+++ b/test_hybrid_engine.py
@@ -1,0 +1,42 @@
+import asyncio
+from knowledge_storm import STORMConfig, EnhancedSTORMEngine
+
+
+def test_config_modes():
+    cfg = STORMConfig()
+    assert cfg.mode == "hybrid"
+    assert cfg.academic_sources
+    assert cfg.quality_gates
+    assert not cfg.citation_verification
+
+    cfg.switch_mode("wikipedia")
+    assert cfg.mode == "wikipedia"
+    assert not cfg.academic_sources
+
+    cfg.switch_mode("academic")
+    assert cfg.citation_verification
+
+
+def test_engine_routing(monkeypatch):
+    cfg = STORMConfig("academic")
+    engine = EnhancedSTORMEngine(cfg)
+
+    async def academic(topic, **kw):
+        return "A"
+
+    async def original(topic, **kw):
+        return "O"
+
+    class Runner:
+        async def run_academic_workflow(self, topic: str, **kw):
+            return await academic(topic, **kw)
+
+        async def run_original_workflow(self, topic: str, **kw):
+            return await original(topic, **kw)
+
+    engine._workflow_runner = Runner()
+
+    assert asyncio.run(engine.generate_article("t")) == "A"
+
+    cfg.switch_mode("wikipedia")
+    assert asyncio.run(engine.generate_article("t")) == "O"

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,0 +1,53 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from knowledge_storm import STORMConfig, EnhancedSTORMEngine
+from knowledge_storm.hybrid_engine import Article
+from knowledge_storm.exceptions import ServiceUnavailableError
+
+
+class TestIntegration:
+    def test_end_to_end_academic_workflow(self):
+        config = STORMConfig("academic")
+        mock_runner = AsyncMock()
+        mock_runner.run_academic_workflow.return_value = Article(
+            topic="quantum computing",
+            content="Detailed academic content...",
+            metadata={"citations": 15, "peer_reviewed": True},
+        )
+
+        engine = EnhancedSTORMEngine(config, mock_runner)
+
+        async def run():
+            return await engine.generate_article("quantum computing")
+
+        result = asyncio.run(run())
+
+        assert result.topic == "quantum computing"
+        assert "academic" in result.content.lower()
+        mock_runner.run_academic_workflow.assert_called_once()
+
+    def test_fallback_on_academic_workflow_failure(self):
+        config = STORMConfig("academic")
+        mock_runner = AsyncMock()
+        mock_runner.run_academic_workflow.side_effect = ServiceUnavailableError(
+            "Academic service down"
+        )
+        mock_runner.run_original_workflow.return_value = Article(
+            topic="quantum computing",
+            content="Basic article content...",
+        )
+
+        engine = EnhancedSTORMEngine(config, mock_runner)
+
+        async def run():
+            with patch.object(engine, '_generate_standard_article') as fallback_mock:
+                fallback_mock.return_value = Article(topic="quantum computing", content="fallback")
+                result = await engine.generate_article("quantum computing")
+                assert result.content == "fallback"
+                fallback_mock.assert_called_once()
+
+        asyncio.run(run())
+
+

--- a/test_performance.py
+++ b/test_performance.py
@@ -1,0 +1,44 @@
+import asyncio
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from knowledge_storm import STORMConfig, EnhancedSTORMEngine
+
+
+class TestPerformance:
+    def test_concurrent_article_generation(self):
+        config = STORMConfig("hybrid")
+        engine = EnhancedSTORMEngine(config)
+
+        async def run():
+            start = time.perf_counter()
+            tasks = [engine.generate_article(f"topic_{i}") for i in range(10)]
+            results = await asyncio.gather(*tasks)
+            end = time.perf_counter()
+            return results, end - start
+
+        results, duration = asyncio.run(run())
+
+        assert len(results) == 10
+        assert all(article.topic.startswith("topic_") for article in results)
+        assert duration < 1.0
+
+    def test_thread_safe_mode_switching(self):
+        config = STORMConfig("hybrid")
+
+        def switch_mode_repeatedly():
+            for _ in range(100):
+                config.switch_mode("academic")
+                config.switch_mode("wikipedia")
+                config.switch_mode("hybrid")
+
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = [executor.submit(switch_mode_repeatedly) for _ in range(5)]
+            for future in futures:
+                future.result()
+
+        assert config.mode in ["academic", "wikipedia", "hybrid"]
+
+


### PR DESCRIPTION
## Summary
- implement STORMMode enum and strict validator
- add STORMConfig with runtime mode switching and validation
- introduce environment configuration helpers
- refactor hybrid engine with workflow selector and fallback logic
- persist configuration to JSON
- add comprehensive unit, performance, and integration tests
- **fix thread safety with locking and narrow academic workflow exceptions**

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686895ce4664832288fd3108378d5648