### PR TITLE
Add academic workflow runner

### DIFF
--- a/knowledge_storm/__init__.py
+++ b/knowledge_storm/__init__.py
@@ -10,6 +10,7 @@ except ModuleNotFoundError:  # pragma: no cover - handled for optional deps
 from . import interface  # noqa: F401
 from .storm_config import STORMConfig  # noqa: F401
 from .hybrid_engine import EnhancedSTORMEngine  # noqa: F401
+from .workflows.academic import AcademicWorkflowRunner  # noqa: F401
 from .exceptions import ServiceUnavailableError  # noqa: F401
 try:
     from .storm_wiki import utils  # noqa: F401
@@ -24,4 +25,5 @@ __all__ = [
     "STORMConfig",
     "EnhancedSTORMEngine",
     "ServiceUnavailableError",
+    "AcademicWorkflowRunner",
 ]

--- a/knowledge_storm/workflows/academic.py
+++ b/knowledge_storm/workflows/academic.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from knowledge_storm.hybrid_engine import Article, WorkflowRunner
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - optional dependency
+    from knowledge_storm.storm_wiki.engine import STORMWikiRunner
+
+
+@dataclass
+class AcademicWorkflowRunner(WorkflowRunner):
+    """Run the full STORM academic workflow using a STORMWikiRunner."""
+
+    storm_runner: "STORMWikiRunner"
+
+    async def run_academic_workflow(self, topic: str, **kwargs: Any) -> Article:
+        await self.storm_runner.run(
+            topic=topic,
+            do_research=True,
+            do_generate_outline=True,
+            do_generate_article=True,
+            do_polish_article=True,
+        )
+        self.storm_runner.post_run()
+
+        article_dir = os.path.join(
+            self.storm_runner.args.output_dir,
+            topic.replace(" ", "_").replace("/", "_"),
+        )
+        article_path = os.path.join(article_dir, "storm_gen_article_polished.txt")
+        content = ""
+        if os.path.exists(article_path):
+            with open(article_path, "r", encoding="utf-8") as f:
+                content = f.read()
+        return Article(topic=topic, content=content, metadata={"type": "academic"})
+
+    async def run_original_workflow(self, topic: str, **kwargs: Any) -> Article:
+        return await self.run_academic_workflow(topic, **kwargs)

--- a/test_academic_workflow_runner.py
+++ b/test_academic_workflow_runner.py
@@ -1,0 +1,27 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from knowledge_storm.workflows.academic import AcademicWorkflowRunner
+from knowledge_storm.hybrid_engine import Article
+
+
+async def run_runner(tmp_path):
+    runner = AsyncMock()
+    runner.args = SimpleNamespace(output_dir=str(tmp_path))
+    runner.post_run = Mock()
+    article_dir = tmp_path / "topic"
+    article_dir.mkdir()
+    (article_dir / "storm_gen_article_polished.txt").write_text("result")
+    awr = AcademicWorkflowRunner(runner)
+    result = await awr.run_academic_workflow("topic")
+    runner.run.assert_awaited_once()
+    runner.post_run.assert_called_once()
+    return result
+
+
+def test_academic_workflow_runner(tmp_path):
+    article = asyncio.run(run_runner(tmp_path))
+    assert isinstance(article, Article)
+    assert article.topic == "topic"
+    assert article.content == "result"


### PR DESCRIPTION
## Summary
- create `AcademicWorkflowRunner` that drives a `STORMWikiRunner`
- expose the new runner in the package API
- test the workflow runner

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868a835e3688322b3db1a3888387772