### PR TITLE
Add crossref retrieval

### DIFF
--- a/test_crossref_rm.py
+++ b/test_crossref_rm.py
@@ -1,0 +1,27 @@
+import pytest
+
+pytest.importorskip("dspy")
+from knowledge_storm.rm import CrossrefRM
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+
+
+def test_crossref_rm_basic(monkeypatch):
+    sample = {
+        "message": {
+            "items": [
+                {"URL": "http://example.com", "title": ["Sample"], "abstract": "A"}
+            ]
+        }
+    }
+    def fake_get(url, params=None):
+        return DummyResp(sample)
+    monkeypatch.setattr("knowledge_storm.rm.requests.get", fake_get)
+    rm = CrossrefRM(k=1)
+    results = rm.forward("test")
+    assert results == [{"url": "http://example.com", "title": "Sample", "description": "A", "snippets": ["A"]}]
+


### PR DESCRIPTION
## Summary
- implement optional backoff import in rm module
- add `CrossrefRM` retrieval class for Crossref search
- create basic tests for CrossrefRM

## Testing
- `pytest -q test_crossref_rm.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868a835e3688322b3db1a3888387772