### PR TITLE
Implement ResearchPlanner utility

### DIFF
--- a/knowledge_storm/__init__.py
+++ b/knowledge_storm/__init__.py
@@ -11,6 +11,7 @@ from . import interface  # noqa: F401
 from .storm_config import STORMConfig  # noqa: F401
 from .hybrid_engine import EnhancedSTORMEngine  # noqa: F401
 from .exceptions import ServiceUnavailableError  # noqa: F401
+from .services.research_planner import ResearchPlanner  # noqa: F401
 try:
     from .storm_wiki import utils  # noqa: F401
 except ModuleNotFoundError:  # pragma: no cover
@@ -24,4 +25,5 @@ __all__ = [
     "STORMConfig",
     "EnhancedSTORMEngine",
     "ServiceUnavailableError",
+    "ResearchPlanner",
 ]

--- a/knowledge_storm/services/research_planner.py
+++ b/knowledge_storm/services/research_planner.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict, List
+
+from .academic_source_service import DEFAULT_LIMIT
+from .cache_service import CacheService
+from ..storm_config import STORMConfig
+
+
+class ResearchPlanner:
+    """Simple research planning utility."""
+
+    def __init__(self, cache: CacheService | None = None, config: STORMConfig | None = None) -> None:
+        self.cache = cache or CacheService()
+        self.config = config or STORMConfig()
+
+    async def analyze_topic_complexity(self, topic: str) -> int:
+        """Return a naive complexity score based on unique words."""
+        words = set(topic.lower().split())
+        return len(words)
+
+    async def generate_research_strategy(self, topic: str, complexity: int) -> List[str]:
+        """Generate a basic research strategy for a topic."""
+        strategy = [
+            f"Define scope for '{topic}'.",
+            "Search OpenAlex and Crossref for recent papers.",
+        ]
+        if self.config.academic_sources:
+            strategy.append("Prioritize peer-reviewed sources.")
+        if complexity > 5:
+            strategy.append("Break topic into subtopics and research separately.")
+        return strategy
+
+    async def optimize_multi_perspective_plan(self, perspectives: List[str]) -> List[str]:
+        """Deduplicate and sort perspectives."""
+        return sorted(set(perspectives))
+
+    async def get_plan(self, topic: str) -> Dict[str, Any]:
+        """Return a cached research plan for the topic."""
+        key = f"plan:{hashlib.md5(topic.encode()).hexdigest()}"
+        cached = await self.cache.get(key)
+        if cached:
+            return cached
+        complexity = await self.analyze_topic_complexity(topic)
+        strategy = await self.generate_research_strategy(topic, complexity)
+        plan = {"topic": topic, "complexity": complexity, "strategy": strategy}
+        await self.cache.set(key, plan)
+        return plan


### PR DESCRIPTION
## Summary
- introduce `ResearchPlanner` for topic complexity analysis and basic strategy generation
- expose `ResearchPlanner` via package `__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a835e3688322b3db1a3888387772