### PR TITLE
Complete Academic Research Workflow Integration

### DIFF
--- a/knowledge_storm/agents/__init__.py
+++ b/knowledge_storm/agents/__init__.py
@@ -1,7 +1,6 @@
-
 from .base import Agent
 from .researcher import AcademicResearcherAgent
 from .critic import CriticAgent
 from .citation_verifier import CitationVerifierAgent
 from .writer import WriterAgent
-
+from .planner import ResearchPlannerAgent

--- a/knowledge_storm/agents/planner.py
+++ b/knowledge_storm/agents/planner.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+
+from .base import Agent
+
+
+class ResearchPlannerAgent(Agent):
+    """Agent that produces research plans for academic topics."""
+
+    def __init__(self, agent_id: str, name: str, role: str = "Research Planner") -> None:
+        super().__init__(agent_id, name, role)
+        # Import here to avoid circular dependency
+        from ..services.research_planner import ResearchPlanner
+        self.planner = ResearchPlanner()
+
+    async def execute_task(self, task: str) -> Dict[str, Any]:
+        """Execute research planning task."""
+        return await self.planner.plan_research(task)
+
+    async def communicate(self, message: str) -> str:
+        """Handle communication with other agents."""
+        await asyncio.sleep(0)
+        return f"{self.name} notes: {message}"

--- a/knowledge_storm/modules/multi_agent_knowledge_curation.py
+++ b/knowledge_storm/modules/multi_agent_knowledge_curation.py
@@ -7,6 +7,11 @@ from knowledge_storm.agent_coordinator import AgentCoordinator
 from knowledge_storm.agents.researcher import AcademicResearcherAgent
 from knowledge_storm.agents.critic import CriticAgent
 from knowledge_storm.agents.citation_verifier import CitationVerifierAgent
+from knowledge_storm.agents.planner import ResearchPlannerAgent
+from typing import Any
+import logging
+
+logger = logging.getLogger(__name__)
 
 class MultiAgentKnowledgeCurationModule(KnowledgeCurationModule):
     def __init__(self, retriever, persona_generator, conv_simulator_lm, question_asker_lm, max_search_queries_per_turn, search_top_k, max_conv_turn, max_thread_num):
@@ -21,38 +26,66 @@ class MultiAgentKnowledgeCurationModule(KnowledgeCurationModule):
         self.coordinator = AgentCoordinator()
 
         # Register agents
+        self.planner = ResearchPlannerAgent(agent_id="planner", name="Research Planner")
         self.researcher = AcademicResearcherAgent(agent_id="researcher", name="Academic Researcher")
         self.critic = CriticAgent(agent_id="critic", name="Critic")
         self.verifier = CitationVerifierAgent(agent_id="verifier", name="Citation Verifier")
 
+        self.coordinator.register_agent(self.planner)
         self.coordinator.register_agent(self.researcher)
         self.coordinator.register_agent(self.critic)
         self.coordinator.register_agent(self.verifier)
 
-    async def research(self, topic, ground_truth_url="", callback_handler=None, max_perspective=3, disable_perspective=False, return_conversation_log=True):
-        # Placeholder for multi-agent research logic
-        # This will involve orchestrating calls to self.coordinator.distribute_task
-        # and potentially self.coordinator.distribute_tasks_parallel
-        # The output should be an InformationTable and a conversation_log
+    async def _safely_execute_task(self, agent_id: str, task: str, task_name: str, fallback: Any) -> Any:
+        """Run a task through the coordinator, returning fallback on failure."""
+        try:
+            return await self.coordinator.distribute_task(agent_id, task)
+        except Exception as e:  # pragma: no cover - network or agent failure
+            logger.warning(f"{task_name} failed for {task}: {e}")
+            return fallback
+
+    async def research(self, topic, ground_truth_url="", callback_handler=None, max_perspective=0, disable_perspective=True, return_conversation_log=False):
+        """Research using multi-agent coordination with error handling."""
         print(f"Performing multi-agent research on topic: {topic}")
 
-        research_result = await self.coordinator.distribute_task(
-            self.researcher.agent_id, topic
+        plan_result = await self._safely_execute_task(
+            self.planner.agent_id,
+            topic,
+            "Planning",
+            {"error": "Planning failed", "topic": topic},
         )
 
-        critique_task = (self.critic.agent_id, topic)
-        verify_task = (self.verifier.agent_id, topic)
-        critique_result, verify_result = await self.coordinator.distribute_tasks_parallel(
-            [critique_task, verify_task]
+        research_result = await self._safely_execute_task(
+            self.researcher.agent_id,
+            topic,
+            "Research",
+            "Research failed",
+        )
+
+        critique_result = await self._safely_execute_task(
+            self.critic.agent_id,
+            research_result,
+            "Critique",
+            "Critique failed",
+        )
+
+        verify_result = await self._safely_execute_task(
+            self.verifier.agent_id,
+            research_result,
+            "Verification",
+            "Verification failed",
         )
 
         conversations = [
+            (self.planner.name, [DialogueTurn(agent_utterance=str(plan_result))]),
             (self.researcher.name, [DialogueTurn(agent_utterance=research_result)]),
             (self.critic.name, [DialogueTurn(agent_utterance=critique_result)]),
             (self.verifier.name, [DialogueTurn(agent_utterance=verify_result)]),
         ]
 
-        info_table = StormInformationTable(conversations)
-        conv_log = StormInformationTable.construct_log_dict(conversations)
+        info_table = StormInformationTable()
+        info_table.conversations = conversations
 
-        return info_table, conv_log
+        if return_conversation_log:
+            return info_table, conversations
+        return info_table

--- a/knowledge_storm/services/research_planner.py
+++ b/knowledge_storm/services/research_planner.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from .cache_service import CacheService
+
+logger = logging.getLogger(__name__)
+
+
+class ResearchPlanner:
+    """Service for planning academic research workflows."""
+
+    def __init__(self, cache: CacheService | None = None) -> None:
+        self.cache = cache or CacheService()
+
+    async def analyze_topic_complexity(self, topic: str) -> int:
+        """Return complexity score based on word count."""
+        if not topic or not topic.strip():
+            return 1
+        return min(len(topic.split()), 10)  # Cap at 10
+
+    async def generate_research_strategy(self, topic: str, complexity: int) -> Dict[str, Any]:
+        """Generate basic research plan for the given topic."""
+        base_steps = [
+            "scope topic",
+            "search literature",
+            "analyze findings",
+            "draft article"
+        ]
+
+        if complexity > 5:
+            base_steps.insert(1, "break into subtopics")
+
+        return {
+            "topic": topic,
+            "complexity": complexity,
+            "steps": base_steps,
+            "estimated_time": complexity * 2  # hours
+        }
+
+
+    async def plan_research(self, topic: str) -> Dict[str, Any]:
+        """End-to-end planning with caching and error handling."""
+        if not topic or not topic.strip():
+            raise ValueError("Topic cannot be empty")
+
+        cache_key = f"plan:{topic.strip()}"
+
+        try:
+            cached = await self.cache.get(cache_key)
+            if cached is not None:
+                logger.debug(f"Retrieved cached plan for topic: {topic}")
+                return cached
+        except Exception as e:
+            logger.warning(f"Cache retrieval failed for {topic}: {e}")
+            # Continue without cache
+
+        try:
+            complexity = await self.analyze_topic_complexity(topic)
+            strategy = await self.generate_research_strategy(topic, complexity)
+
+            # Attempt to cache result
+            try:
+                await self.cache.set(cache_key, strategy)
+            except Exception as e:
+                logger.warning(f"Cache storage failed for {topic}: {e}")
+                # Continue without caching
+
+            return strategy
+
+        except Exception as e:
+            logger.error(f"Research planning failed for {topic}: {e}")
+            # Return minimal fallback plan
+            return {
+                "topic": topic,
+                "complexity": 1,
+                "steps": ["search literature", "draft article"],
+                "estimated_time": 2,
+                "error": "Planning failed, using fallback"
+            }

--- a/test_research_planner.py
+++ b/test_research_planner.py
@@ -1,0 +1,68 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+import pytest
+
+from knowledge_storm.services.research_planner import ResearchPlanner
+from knowledge_storm.agents.planner import ResearchPlannerAgent
+
+
+def test_research_planner_basic():
+    planner = ResearchPlanner()
+    plan = asyncio.run(planner.plan_research("quantum computing"))
+    assert plan["topic"] == "quantum computing"
+    assert plan["steps"]
+
+
+def test_research_planner_agent_execution():
+    planner = ResearchPlanner()
+    agent = ResearchPlannerAgent("p", "Planner")
+    agent.planner = planner
+    result = asyncio.run(agent.execute_task("machine learning"))
+    assert "steps" in result
+
+
+def test_plan_research_validates_topic():
+    planner = ResearchPlanner()
+    with pytest.raises(ValueError):
+        asyncio.run(planner.plan_research(""))
+
+
+def test_analyze_topic_complexity_caps_at_10():
+    planner = ResearchPlanner()
+    topic = "word " * 20
+    complexity = asyncio.run(planner.analyze_topic_complexity(topic))
+    assert complexity == 10
+
+
+def test_multi_agent_module_returns_plan():
+    import sys
+    import types
+    import pytest
+
+    # Provide minimal dspy modules so import does not fail
+    dspy_mod = types.ModuleType("dspy")
+    dsp_mod = types.ModuleType("dspy.dsp")
+    modules_mod = types.ModuleType("dspy.dsp.modules")
+    lm_mod = types.ModuleType("dspy.dsp.modules.lm")
+    dspy_mod.dsp = dsp_mod
+    sys.modules.setdefault("dspy", dspy_mod)
+    sys.modules.setdefault("dspy.dsp", dsp_mod)
+    sys.modules.setdefault("dspy.dsp.modules", modules_mod)
+    sys.modules.setdefault("dspy.dsp.modules.lm", lm_mod)
+
+    mod = pytest.importorskip("knowledge_storm.modules.multi_agent_knowledge_curation")
+    MultiAgentKnowledgeCurationModule = mod.MultiAgentKnowledgeCurationModule
+
+    module = MultiAgentKnowledgeCurationModule(None, None, None, None, 1, 1, 1, 1)
+    with patch(
+        "knowledge_storm.services.academic_source_service.AcademicSourceService.search_openalex",
+        new=AsyncMock(return_value=[{"title": "A"}]),
+    ), patch(
+        "knowledge_storm.services.academic_source_service.AcademicSourceService.search_crossref",
+        new=AsyncMock(return_value=[{"title": "B"}]),
+    ), patch(
+        "knowledge_storm.services.academic_source_service.AcademicSourceService.get_publication_metadata",
+        new=AsyncMock(return_value={}),
+    ):
+        table, _ = asyncio.run(module.research("topic"))
+        assert table.conversations[0][0] == "Research Planner"


### PR DESCRIPTION
## Summary
- fix circular import for ResearchPlannerAgent
- remove duplicate agent definition from models
- add error handling and caching to ResearchPlanner service
- improve multi-agent coordination with logging and error handling
- update tests for new planner agent
- add helper to reduce error handling duplication and strengthen tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868a835e3688322b3db1a3888387772