### PR TITLE
Add demo script and interface protocols

### DIFF
--- a/academic_validation_framework/__init__.py
+++ b/academic_validation_framework/__init__.py
@@ -21,27 +21,11 @@ from .validators import (
     PRISMAValidator,
     CitationAccuracyValidator,
 )
-from .benchmarks import (
-    PerformanceBenchmarkSuite,
-)
-from .database_integrations import (
-    BaseDatabaseIntegrationTester,
-)
-from .credibility import (
-    BaseCredibilityAssessment,
-)
-from .reporting import (
-    BaseReportGenerator,
-)
 
 __all__ = [
     "AcademicValidationFramework",
     "PRISMAValidator",
-    "CitationAccuracyValidator", 
-    "PerformanceBenchmarkSuite",
-    "BaseDatabaseIntegrationTester",
-    "BaseCredibilityAssessment",
-    "BaseReportGenerator",
+    "CitationAccuracyValidator",
 ]
 
 __version__ = "1.0.0"

--- a/academic_validation_framework/interfaces_v2.py
+++ b/academic_validation_framework/interfaces_v2.py
@@ -1,0 +1,116 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+@dataclass
+class ValidationResult:
+    """Simple validation result data structure."""
+    test_name: str
+    passed: bool
+    score: float
+    details: Dict[str, Any]
+    error_message: str = ""
+    execution_time_seconds: float = 0.0
+    timestamp: datetime = None
+
+    def __post_init__(self) -> None:
+        if self.timestamp is None:
+            self.timestamp = datetime.now()
+
+@dataclass
+class ResearchData:
+    """Simplified research data structure for validation."""
+    title: str
+    abstract: str
+    methodology_section: str
+    search_terms: Optional[List[str]] = None
+    databases_searched: Optional[List[str]] = None
+    inclusion_criteria: Optional[List[str]] = None
+    exclusion_criteria: Optional[List[str]] = None
+    studies_found: int = 0
+    studies_included: int = 0
+    data_extraction_method: str = ""
+    quality_assessment_tool: str = ""
+    references: Optional[List[Dict[str, str]]] = None
+
+    def __post_init__(self) -> None:
+        self.search_terms = self.search_terms or []
+        self.databases_searched = self.databases_searched or []
+        self.inclusion_criteria = self.inclusion_criteria or []
+        self.exclusion_criteria = self.exclusion_criteria or []
+        self.references = self.references or []
+
+class ValidatorProtocol(ABC):
+    """Protocol for all validation components."""
+
+    @abstractmethod
+    async def validate(self, data: Any) -> ValidationResult:
+        pass
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        pass
+
+    @property
+    @abstractmethod
+    def supported_data_types(self) -> List[type]:
+        pass
+
+class BenchmarkProtocol(ABC):
+    """Protocol for benchmark components."""
+
+    @abstractmethod
+    async def benchmark(self, target: Any, config: Optional[Dict[str, Any]] = None) -> ValidationResult:
+        pass
+
+    @property
+    @abstractmethod
+    def benchmark_categories(self) -> List[str]:
+        pass
+
+class DatabaseIntegrationProtocol(ABC):
+    """Protocol for database integration testing."""
+
+    @abstractmethod
+    async def test_integration(self, config: Dict[str, Any]) -> ValidationResult:
+        pass
+
+    @property
+    @abstractmethod
+    def supported_databases(self) -> List[str]:
+        pass
+
+class CredibilityAssessorProtocol(ABC):
+    """Protocol for credibility assessment."""
+
+    @abstractmethod
+    async def assess_credibility(self, research_data: ResearchData) -> ValidationResult:
+        pass
+
+    @property
+    @abstractmethod
+    def assessment_criteria(self) -> List[str]:
+        pass
+
+class ReportGeneratorProtocol(ABC):
+    """Protocol for report generation."""
+
+    @abstractmethod
+    async def generate_report(self, results: List[ValidationResult], config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        pass
+
+    @property
+    @abstractmethod
+    def supported_formats(self) -> List[str]:
+        pass
+
+class ValidationError(Exception):
+    pass
+
+class ConfigurationError(Exception):
+    pass
+
+class IntegrationError(Exception):
+    pass

--- a/academic_validation_framework/validators/citation_accuracy_validator.py
+++ b/academic_validation_framework/validators/citation_accuracy_validator.py
@@ -4,7 +4,11 @@ Citation Accuracy Validator for academic research validation.
 This module imports and uses the real citation validator implementation.
 """
 
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
+
+from ..models import ValidationResult
+
+from .base import ValidationContext
 
 # Import the real implementation
 from .real_citation_validator import RealCitationValidator

--- a/demo_real_validation.py
+++ b/demo_real_validation.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Demonstration of real academic validation using built-in validators."""
+import asyncio
+from academic_validation_framework.core import AcademicValidationFramework
+from academic_validation_framework.config import FrameworkConfig
+from academic_validation_framework.validators.real_prisma_validator import RealPRISMAValidator
+from academic_validation_framework.validators.real_citation_validator import RealCitationValidator
+from academic_validation_framework.models import ResearchData
+
+async def main() -> None:
+    print("\U0001F393 Academic Validation Framework Demo")
+    print("=" * 40)
+
+    config = FrameworkConfig(console_logging=True)
+    framework = AcademicValidationFramework(config)
+    framework.register_validator(RealPRISMAValidator())
+    framework.register_validator(RealCitationValidator())
+
+    high_quality = ResearchData(
+        title="Machine Learning in Medical Diagnosis: A Systematic Review",
+        abstract=(
+            "This systematic review examines ML applications in medical diagnosis. "
+            "Protocol registered in PROSPERO."
+        ),
+        methodology="Search strategy used Boolean operators across PubMed, Cochrane, and Embase from 2010-2023. Independent reviewers performed standardized extraction.",
+        search_terms=["machine learning", "medical diagnosis", "artificial intelligence", "clinical decision"],
+        databases_used=["PubMed", "Cochrane", "Embase", "IEEE Xplore"],
+        inclusion_criteria=["peer-reviewed", "English", "clinical studies"],
+        exclusion_criteria=["case reports", "conference abstracts"],
+        citations=[
+            "Smith, J. A. (2023). Machine learning in healthcare. Journal of Medical AI, 15(3), 245-267.",
+            'Johnson, Mary. "AI in Diagnosis." Medical Technology, vol. 12, no. 4, 2023, pp. 100-115.',
+            "Some paper by someone about AI"
+        ]
+    )
+
+    poor_quality = ResearchData(
+        title="Some Review",
+        abstract="We looked at some stuff.",
+        methodology="We searched Google Scholar.",
+        search_terms=["ML"],
+        databases_used=["Google Scholar"],
+        inclusion_criteria=["relevant"],
+        exclusion_criteria=[],
+        citations=["Bad citation format"]
+    )
+
+    print("\n\U0001F4CA Testing High-Quality Research Data:")
+    good_prisma = await framework.validators[0].validate(high_quality)
+    print(f"   PRISMA Score: {good_prisma.score:.2f} (Pass: {good_prisma.passed})")
+
+    print("\n\U0001F4C9 Testing Poor-Quality Research Data:")
+    bad_prisma = await framework.validators[0].validate(poor_quality)
+    print(f"   PRISMA Score: {bad_prisma.score:.2f} (Pass: {bad_prisma.passed})")
+
+    print("\n\U0001F4DD Testing Citation Validation:")
+    citation_result = await framework.validators[1].validate(high_quality)
+    print(f"   Citation Score: {citation_result.score:.2f} (Pass: {citation_result.passed})")
+
+    print("\n\u2705 Demo Complete")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add new typed protocol definitions in `interfaces_v2.py`
- fix CitationAccuracyValidator imports
- slim down package `__init__` to avoid heavy optional deps
- provide `demo_real_validation.py` to show real validator usage

## Testing
- `python demo_real_validation.py`
- `pytest -q` *(fails: unexpected line in pytest.ini)*

------
https://chatgpt.com/codex/tasks/task_e_686ba2eb99cc832295232bd57602d6c2