### PR TITLE
Implement PRISMA 80/20 screening assistant

### DIFF
--- a/PRISMA_80_20_SUMMARY.md
+++ b/PRISMA_80_20_SUMMARY.md
@@ -1,0 +1,23 @@
+# PRISMA Assistant 80/20 Screening System
+
+This module provides a lightweight implementation of an automated screening
+assistant inspired by the PRISMA guidelines. The goal is to rapidly exclude
+clearly irrelevant sources and include highly relevant ones with approximately
+80% confidence.
+
+## Overview
+
+`PRISMAScreener` counts keyword hits for inclusion and exclusion patterns.
+Scores are calculated as the fraction of hits relative to the number of
+patterns. A record is included or excluded when the respective score meets or
+exceeds the configured threshold (default `0.8`) **and** is greater than the
+opposite score. If exclusion keywords outnumber inclusion keywords the record is
+excluded even when scores fall below the threshold. In all other cases the
+decision is marked as `unsure`.
+
+The `ScreeningResult` dataclass captures the decision, confidence and reasoning
+used for each record. Batched screening is supported via `batch_screen`.
+
+This implementation is deliberately simple to demonstrate the 80/20 workflow. In
+practice the patterns and scoring logic can be extended with additional signals
+or machine learning models.

--- a/demo_80_20_screening.py
+++ b/demo_80_20_screening.py
@@ -1,0 +1,15 @@
+"""Demonstration of the PRISMA 80/20 screening assistant."""
+
+from knowledge_storm.prisma_assistant import PRISMAScreener
+
+
+if __name__ == "__main__":
+    screener = PRISMAScreener()
+    records = [
+        "Randomized controlled trial of new therapy shows positive results",
+        "Study protocol for upcoming clinical trial",
+        "Editorial commentary on research methods",
+    ]
+    for rec in records:
+        result = screener.screen(rec)
+        print(f"{rec}\n  -> {result.decision} (confidence {result.confidence:.2f})")

--- a/knowledge_storm/modules/__init__.py
+++ b/knowledge_storm/modules/__init__.py
@@ -1,4 +1,8 @@
-from .academic_rm import CrossrefRM
+try:
+    from .academic_rm import CrossrefRM  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    CrossrefRM = None  # type: ignore
+
 from .multi_agent_knowledge_curation import MultiAgentKnowledgeCurationModule
 
 __all__ = ["CrossrefRM", "MultiAgentKnowledgeCurationModule"]

--- a/knowledge_storm/prisma_assistant.py
+++ b/knowledge_storm/prisma_assistant.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass
+class ScreeningResult:
+    """Result of screening a single record."""
+
+    decision: str
+    confidence: float
+    reasons: List[str]
+
+
+class PRISMAScreener:
+    """Simple 80/20 screening assistant.
+
+    Keyword patterns are counted to derive inclusion and exclusion scores.
+    A record is included or excluded when the corresponding score meets or
+    exceeds ``threshold`` (default ``0.8``) **and** is greater than the
+    opposite score. If exclusion keywords outnumber inclusion keywords, the
+    record is excluded even when scores fall below the threshold. Any other
+    case results in an ``unsure`` decision.
+    """
+
+    def __init__(
+        self,
+        include_patterns: List[str] | None = None,
+        exclude_patterns: List[str] | None = None,
+        threshold: float = 0.8,
+    ) -> None:
+        self.include_patterns = include_patterns or [
+            "randomized",
+            "controlled",
+            "trial",
+            "study",
+            "results",
+        ]
+        self.exclude_patterns = exclude_patterns or [
+            "protocol",
+            "editorial",
+            "letter",
+            "commentary",
+            "case report",
+        ]
+        self.threshold = threshold
+
+    def _hits(self, text: str) -> Tuple[int, int]:
+        text = text.lower()
+        inc_hits = sum(1 for p in self.include_patterns if p in text)
+        exc_hits = sum(1 for p in self.exclude_patterns if p in text)
+        return inc_hits, exc_hits
+
+    @staticmethod
+    def _score(hits: int, total: int) -> float:
+        return hits / total if total else 0.0
+
+    def screen(self, text: str) -> ScreeningResult:
+        """Screen a single text and return the decision."""
+        inc_hits, exc_hits = self._hits(text)
+        inc_score = self._score(inc_hits, len(self.include_patterns))
+        exc_score = self._score(exc_hits, len(self.exclude_patterns))
+
+        if inc_score >= self.threshold and inc_score > exc_score:
+            return ScreeningResult(
+                "include",
+                inc_score,
+                [f"include score {inc_score:.2f} >= {self.threshold}"]
+            )
+
+        if exc_score >= self.threshold and exc_score > inc_score:
+            return ScreeningResult(
+                "exclude",
+                exc_score,
+                [f"exclude score {exc_score:.2f} >= {self.threshold}"]
+            )
+
+        if exc_hits >= 1 and inc_hits <= exc_hits:
+            return ScreeningResult(
+                "exclude",
+                exc_score,
+                [f"{exc_hits} exclude hits >= {inc_hits} include hits"]
+            )
+
+        return ScreeningResult(
+            "unsure",
+            max(inc_score, exc_score),
+            ["scores below threshold or conflicting"]
+        )
+
+    def batch_screen(self, texts: List[str]) -> List[ScreeningResult]:
+        """Screen multiple texts at once."""
+        return [self.screen(t) for t in texts]

--- a/test_prisma_assistant.py
+++ b/test_prisma_assistant.py
@@ -1,0 +1,43 @@
+from knowledge_storm.prisma_assistant import PRISMAScreener
+
+
+def test_screen_include():
+    screener = PRISMAScreener(threshold=0.4)
+    text = "Randomized controlled trial evaluating outcomes"
+    result = screener.screen(text)
+    assert result.decision == "include"
+    assert result.confidence == 0.6
+
+
+def test_screen_exclude():
+    screener = PRISMAScreener(threshold=0.4)
+    text = "Protocol for an upcoming trial"
+    result = screener.screen(text)
+    assert result.decision == "exclude"
+    assert result.confidence == 0.2
+
+
+def test_screen_unsure():
+    screener = PRISMAScreener(threshold=0.4)
+    text = "Preliminary findings"
+    result = screener.screen(text)
+    assert result.decision == "unsure"
+    assert result.confidence == 0.0
+
+
+def test_conflict_resolution():
+    screener = PRISMAScreener(threshold=0.4)
+    text = "Randomized trial protocol commentary"
+    result = screener.screen(text)
+    assert result.decision == "exclude"
+    assert result.confidence == 0.4
+
+
+def test_batch_screen():
+    screener = PRISMAScreener(threshold=0.4)
+    records = [
+        "Randomized trial results",
+        "Editorial commentary"
+    ]
+    decisions = [r.decision for r in screener.batch_screen(records)]
+    assert decisions == ["include", "exclude"]


### PR DESCRIPTION
## Summary
- add simple PRISMA 80/20 screening module
- demonstrate usage in `demo_80_20_screening.py`
- document the module in `PRISMA_80_20_SUMMARY.md`
- expose modules conditionally to avoid failing imports when optional deps are missing
- test screening logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687077238c2083229867e82a6314a3a4