### PR TITLE
Improve PRISMA screener implementation

### DIFF
--- a/PRISMA_80_20_SUMMARY.md
+++ b/PRISMA_80_20_SUMMARY.md
@@ -1,0 +1,22 @@
+# PRISMA Assistant 80/20 Screening System
+
+This module provides a lightweight implementation of an automated screening
+assistant inspired by the PRISMA guidelines. The goal is to rapidly exclude
+clearly irrelevant sources and include highly relevant ones with approximately
+80% confidence.
+
+## Overview
+
+`PRISMAScreener` uses inclusion and exclusion keyword patterns. For each record
+the number of hits is converted to a score (hits divided by total patterns).
+When a score meets the configured threshold (default `0.8`) **and** exceeds the
+opposing score, the record is automatically included or excluded. If both types
+of keywords appear but the threshold is not reached, the screener defaults to
+exclusion. Otherwise the decision is marked as `unsure`.
+
+The `ScreeningResult` dataclass captures the decision, confidence and reasoning
+used for each record. Batched screening is supported via `batch_screen`.
+
+This implementation is deliberately simple to demonstrate the 80/20 workflow. In
+practice the patterns and scoring logic can be extended with additional signals
+or machine learning models.

--- a/demo_80_20_screening.py
+++ b/demo_80_20_screening.py
@@ -1,0 +1,18 @@
+"""Demonstration of the PRISMA 80/20 screening assistant."""
+
+from knowledge_storm.prisma_assistant import PRISMAScreener
+
+
+if __name__ == "__main__":
+    screener = PRISMAScreener()
+    records = [
+        "Randomized controlled trial of new therapy shows positive results",
+        "Study protocol for upcoming clinical trial",
+        "Editorial commentary on research methods",
+    ]
+    for rec in records:
+        result = screener.screen(rec)
+        reason = "; ".join(result.reasons)
+        print(
+            f"{rec}\n  -> {result.decision} (confidence {result.confidence:.2f}) - {reason}"
+        )

--- a/knowledge_storm/modules/__init__.py
+++ b/knowledge_storm/modules/__init__.py
@@ -1,4 +1,13 @@
-from .academic_rm import CrossrefRM
+try:
+    from .academic_rm import CrossrefRM  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    CrossrefRM = None  # type: ignore
+
 from .multi_agent_knowledge_curation import MultiAgentKnowledgeCurationModule
 
-__all__ = ["CrossrefRM", "MultiAgentKnowledgeCurationModule"]
+try:
+    from ..prisma_assistant import PRISMAScreener  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    PRISMAScreener = None  # type: ignore
+
+__all__ = ["CrossrefRM", "MultiAgentKnowledgeCurationModule", "PRISMAScreener"]

--- a/knowledge_storm/prisma_assistant.py
+++ b/knowledge_storm/prisma_assistant.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass
+class ScreeningResult:
+    """Result of screening a single record."""
+
+    decision: str
+    confidence: float
+    reasons: List[str]
+
+
+class PRISMAScreener:
+    """Keyword-based 80/20 screening assistant.
+
+    The screener counts inclusion and exclusion keyword hits. Scores are
+    calculated as the fraction of keywords found. If a score meets the
+    configured threshold (default ``0.8``) and exceeds the opposing score,
+    the record is included or excluded accordingly. When both types of
+    keywords are detected but the threshold is not met, the record is
+    conservatively excluded. Otherwise the decision is ``unsure``.
+    """
+
+    def __init__(
+        self,
+        include_patterns: List[str] | None = None,
+        exclude_patterns: List[str] | None = None,
+        threshold: float = 0.8,
+    ) -> None:
+        self.include_patterns = include_patterns or [
+            "randomized",
+            "controlled",
+            "trial",
+            "study",
+            "results",
+        ]
+        self.exclude_patterns = exclude_patterns or [
+            "protocol",
+            "editorial",
+            "letter",
+            "commentary",
+            "case report",
+        ]
+        self.threshold = threshold
+
+    def _count_hits(self, text: str) -> Tuple[int, int]:
+        text = text.lower()
+        inc_hits = sum(1 for p in self.include_patterns if p in text)
+        exc_hits = sum(1 for p in self.exclude_patterns if p in text)
+        return inc_hits, exc_hits
+
+    def _score(self, inc_hits: int, exc_hits: int) -> Tuple[float, float]:
+        inc_score = inc_hits / len(self.include_patterns)
+        exc_score = exc_hits / len(self.exclude_patterns)
+        return inc_score, exc_score
+
+    def _decide(
+        self, inc_hits: int, exc_hits: int, inc_score: float, exc_score: float
+    ) -> ScreeningResult:
+        if inc_score >= self.threshold and inc_score > exc_score:
+            return ScreeningResult(
+                "include",
+                inc_score,
+                [f"include score {inc_score:.2f} >= {self.threshold}"]
+            )
+
+        if exc_score >= self.threshold and exc_score >= inc_score:
+            return ScreeningResult(
+                "exclude",
+                exc_score,
+                [f"exclude score {exc_score:.2f} >= {self.threshold}"]
+            )
+
+        if inc_hits and exc_hits:
+            return ScreeningResult(
+                "exclude",
+                exc_score,
+                ["conflicting keywords - default exclude"]
+            )
+
+        return ScreeningResult(
+            "unsure", max(inc_score, exc_score), ["scores below threshold"]
+        )
+
+    def screen(self, text: str) -> ScreeningResult:
+        """Screen a single text and return the decision."""
+        inc_hits, exc_hits = self._count_hits(text)
+        inc_score, exc_score = self._score(inc_hits, exc_hits)
+        return self._decide(inc_hits, exc_hits, inc_score, exc_score)
+
+    def batch_screen(self, texts: List[str]) -> List[ScreeningResult]:
+        """Screen multiple texts at once."""
+        return [self.screen(t) for t in texts]

--- a/test_prisma_assistant.py
+++ b/test_prisma_assistant.py
@@ -1,0 +1,43 @@
+from knowledge_storm.prisma_assistant import PRISMAScreener
+
+
+def test_screen_include():
+    screener = PRISMAScreener(threshold=0.5)
+    text = "Randomized controlled trial evaluating outcomes"
+    result = screener.screen(text)
+    assert result.decision == "include"
+    assert result.confidence == 0.6
+
+
+def test_screen_exclude():
+    screener = PRISMAScreener(threshold=0.8)
+    text = "Protocol editorial commentary letter case report"
+    result = screener.screen(text)
+    assert result.decision == "exclude"
+    assert result.confidence == 1.0
+
+
+def test_screen_unsure():
+    screener = PRISMAScreener()
+    text = "Randomized trial results"
+    result = screener.screen(text)
+    assert result.decision == "unsure"
+    assert result.confidence == 0.6
+
+
+def test_conflict_resolution():
+    screener = PRISMAScreener()
+    text = "Randomized trial protocol"
+    result = screener.screen(text)
+    assert result.decision == "exclude"
+    assert result.confidence == 0.2
+
+
+def test_batch_screen():
+    screener = PRISMAScreener(threshold=0.5)
+    records = [
+        "Randomized trial results",
+        "Editorial commentary case report",
+    ]
+    decisions = [r.decision for r in screener.batch_screen(records)]
+    assert decisions == ["include", "exclude"]


### PR DESCRIPTION
## Summary
- refactor `PRISMAScreener` for clearer scoring logic and conflict handling
- expose screener in `knowledge_storm.modules`
- update demo to show decision reasons
- document conflict resolution in PRISMA summary
- expand test coverage with exact confidence checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687077238c2083229867e82a6314a3a4