### PR TITLE
Implement PRISMA 80/20 screening assistant

### DIFF
--- a/PRISMA_80_20_SUMMARY.md
+++ b/PRISMA_80_20_SUMMARY.md
@@ -1,0 +1,21 @@
+# PRISMA Assistant 80/20 Screening System
+
+This module provides a lightweight implementation of an automated screening
+assistant inspired by the PRISMA guidelines. The goal is to rapidly exclude
+clearly irrelevant sources and include highly relevant ones with approximately
+80% confidence.
+
+## Overview
+
+`PRISMAScreener` uses a set of inclusion and exclusion keyword patterns. For
+each record, the number of keyword hits is converted into simple scores. If the
+inclusion or exclusion score exceeds the configured threshold (default `0.8`)
+and is greater than the opposite score, the record is automatically included or
+excluded. Otherwise the decision is marked as `unsure`.
+
+The `ScreeningResult` dataclass captures the decision, confidence and reasoning
+used for each record. Batched screening is supported via `batch_screen`.
+
+This implementation is deliberately simple to demonstrate the 80/20 workflow. In
+practice the patterns and scoring logic can be extended with additional signals
+or machine learning models.

--- a/demo_80_20_screening.py
+++ b/demo_80_20_screening.py
@@ -1,0 +1,15 @@
+"""Demonstration of the PRISMA 80/20 screening assistant."""
+
+from knowledge_storm.prisma_assistant import PRISMAScreener
+
+
+if __name__ == "__main__":
+    screener = PRISMAScreener()
+    records = [
+        "Randomized controlled trial of new therapy shows positive results",
+        "Study protocol for upcoming clinical trial",
+        "Editorial commentary on research methods",
+    ]
+    for rec in records:
+        result = screener.screen(rec)
+        print(f"{rec}\n  -> {result.decision} (confidence {result.confidence:.2f})")

--- a/knowledge_storm/modules/__init__.py
+++ b/knowledge_storm/modules/__init__.py
@@ -1,4 +1,8 @@
-from .academic_rm import CrossrefRM
+try:
+    from .academic_rm import CrossrefRM  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    CrossrefRM = None  # type: ignore
+
 from .multi_agent_knowledge_curation import MultiAgentKnowledgeCurationModule
 
 __all__ = ["CrossrefRM", "MultiAgentKnowledgeCurationModule"]

--- a/knowledge_storm/prisma_assistant.py
+++ b/knowledge_storm/prisma_assistant.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass
+class ScreeningResult:
+    """Result of screening a single record."""
+
+    decision: str
+    confidence: float
+    reasons: List[str]
+
+
+class PRISMAScreener:
+    """Simple 80/20 screening assistant.
+
+    The screener counts inclusion and exclusion keyword hits for a text. Scores
+    are calculated as the fraction of patterns matched. If either score exceeds
+    ``threshold`` (default ``0.8``) and is greater than the opposing score the
+    record is automatically included or excluded. Otherwise the decision is
+    ``unsure``.
+    """
+
+    def __init__(
+        self,
+        include_patterns: List[str] | None = None,
+        exclude_patterns: List[str] | None = None,
+        threshold: float = 0.8,
+    ) -> None:
+        self.include_patterns = include_patterns or [
+            "randomized",
+            "controlled",
+            "trial",
+            "study",
+            "results",
+        ]
+        self.exclude_patterns = exclude_patterns or [
+            "protocol",
+            "editorial",
+            "letter",
+            "commentary",
+            "case report",
+        ]
+        self.threshold = threshold
+
+    def _count_hits(self, text: str) -> Tuple[int, int]:
+        text = text.lower()
+        inc_hits = sum(1 for p in self.include_patterns if p in text)
+        exc_hits = sum(1 for p in self.exclude_patterns if p in text)
+        return inc_hits, exc_hits
+
+    def _calc_scores(self, inc_hits: int, exc_hits: int) -> Tuple[float, float]:
+        inc_score = inc_hits / len(self.include_patterns)
+        exc_score = exc_hits / len(self.exclude_patterns)
+        return inc_score, exc_score
+
+    def _decide(self, inc_score: float, exc_score: float) -> ScreeningResult:
+        if inc_score >= self.threshold and inc_score > exc_score:
+            return ScreeningResult(
+                "include",
+                inc_score,
+                [f"include score {inc_score:.2f} > {exc_score:.2f}"],
+            )
+        if exc_score >= self.threshold and exc_score > inc_score:
+            return ScreeningResult(
+                "exclude",
+                exc_score,
+                [f"exclude score {exc_score:.2f} > {inc_score:.2f}"],
+            )
+        return ScreeningResult(
+            "unsure",
+            max(inc_score, exc_score),
+            ["scores below threshold or conflict"],
+        )
+
+    def screen(self, text: str) -> ScreeningResult:
+        """Screen a single text and return the decision."""
+        hits = self._count_hits(text)
+        scores = self._calc_scores(*hits)
+        return self._decide(*scores)
+
+    def batch_screen(self, texts: List[str]) -> List[ScreeningResult]:
+        """Screen multiple texts at once."""
+        return [self.screen(t) for t in texts]

--- a/test_prisma_assistant.py
+++ b/test_prisma_assistant.py
@@ -1,0 +1,41 @@
+from knowledge_storm.prisma_assistant import PRISMAScreener
+
+
+def test_screen_include_exact_confidence():
+    screener = PRISMAScreener(threshold=0.4)
+    text = "Randomized controlled trial evaluating outcomes"
+    result = screener.screen(text)
+    assert result.decision == "include"
+    assert result.confidence == 0.6
+
+
+def test_screen_exclude_exact_confidence():
+    screener = PRISMAScreener(threshold=0.4)
+    text = "Case report with editorial commentary"
+    result = screener.screen(text)
+    assert result.decision == "exclude"
+    assert result.confidence == 0.6
+
+
+def test_screen_unsure():
+    screener = PRISMAScreener(threshold=0.4)
+    text = "Novel approach to teaching methods"
+    result = screener.screen(text)
+    assert result.decision == "unsure"
+    assert result.confidence == 0.0
+
+
+def test_conflict_include_overrides():
+    screener = PRISMAScreener(threshold=0.3)
+    text = "Randomized trial protocol"
+    result = screener.screen(text)
+    assert result.decision == "include"
+    assert result.confidence == 0.4
+
+
+def test_conflict_exclude_overrides():
+    screener = PRISMAScreener(threshold=0.3)
+    text = "Protocol commentary randomized"
+    result = screener.screen(text)
+    assert result.decision == "exclude"
+    assert result.confidence == 0.4


### PR DESCRIPTION
## Summary
- add simple PRISMA 80/20 screening module
- demonstrate usage in `demo_80_20_screening.py`
- document the module in `PRISMA_80_20_SUMMARY.md`
- expose modules conditionally to avoid failing imports when optional deps are missing
- test screening logic
- refactor screener logic and add unsured/conflict tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687077238c2083229867e82a6314a3a4