### PR TITLE
Improve PRISMA screener edge cases

### DIFF
--- a/PRISMA_80_20_SUMMARY.md
+++ b/PRISMA_80_20_SUMMARY.md
@@ -1,0 +1,22 @@
+# PRISMA Assistant 80/20 Screening System
+
+This module provides a lightweight implementation of an automated screening
+assistant inspired by the PRISMA guidelines. The goal is to rapidly exclude
+clearly irrelevant sources and include highly relevant ones with approximately
+80% confidence.
+
+## Overview
+
+`PRISMAScreener` uses inclusion and exclusion keyword patterns. For each record
+the number of keyword hits is converted into simple scores. When a score
+exceeds the configured threshold (default `0.8`) and is greater than the
+opposite score, the record is automatically included or excluded. If neither
+score meets the threshold, the side with more keyword hits is chosen; if they
+are equal the decision is `unsure`.
+
+The `ScreeningResult` dataclass captures the decision, confidence and reasoning
+used for each record. Batched screening is supported via `batch_screen`.
+
+This implementation is deliberately simple to demonstrate the 80/20 workflow. In
+practice the patterns and scoring logic can be extended with additional signals
+or machine learning models.

--- a/demo_80_20_screening.py
+++ b/demo_80_20_screening.py
@@ -1,0 +1,20 @@
+"""Demonstration of the PRISMA 80/20 screening assistant."""
+
+from knowledge_storm.prisma_assistant import PRISMAScreener
+
+
+if __name__ == "__main__":
+    screener = PRISMAScreener()
+    records = [
+        "Randomized controlled trial of new therapy shows positive results",
+        "Study protocol for upcoming clinical trial",
+        "Editorial commentary on research methods",
+    ]
+    for rec in records:
+        result = screener.screen(rec)
+        reasons = ", ".join(result.reasons)
+        print(
+            f"{rec}\n  -> {result.decision}"
+            f" (confidence {result.confidence:.2f})"
+            f" - {reasons}"
+        )

--- a/knowledge_storm/modules/__init__.py
+++ b/knowledge_storm/modules/__init__.py
@@ -1,4 +1,9 @@
-from .academic_rm import CrossrefRM
-from .multi_agent_knowledge_curation import MultiAgentKnowledgeCurationModule
+try:
+    from .academic_rm import CrossrefRM  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    CrossrefRM = None  # type: ignore
 
-__all__ = ["CrossrefRM", "MultiAgentKnowledgeCurationModule"]
+from .multi_agent_knowledge_curation import MultiAgentKnowledgeCurationModule
+from ..prisma_assistant import PRISMAScreener
+
+__all__ = ["CrossrefRM", "MultiAgentKnowledgeCurationModule", "PRISMAScreener"]

--- a/knowledge_storm/prisma_assistant.py
+++ b/knowledge_storm/prisma_assistant.py
@@ -1,0 +1,122 @@
+"""Lightweight 80/20 screening assistant for systematic reviews."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+
+@dataclass
+class ScreeningResult:
+    """Decision outcome for a single record."""
+
+    decision: str
+    confidence: float
+    reasons: List[str]
+
+
+class PRISMAScreener:
+    """Keyword based helper to approximate PRISMA 80/20 screening."""
+
+    DEFAULT_INCLUDE = ["randomized", "controlled", "trial", "study", "results"]
+    DEFAULT_EXCLUDE = ["protocol", "editorial", "letter", "commentary", "case report"]
+
+    def __init__(
+        self,
+        include_patterns: Sequence[str] | None = None,
+        exclude_patterns: Sequence[str] | None = None,
+        threshold: float = 0.8,
+    ) -> None:
+        self._validate_threshold(threshold)
+        self.include_patterns = (
+            list(include_patterns)
+            if include_patterns is not None
+            else self.DEFAULT_INCLUDE[:]
+        )
+        self.exclude_patterns = (
+            list(exclude_patterns)
+            if exclude_patterns is not None
+            else self.DEFAULT_EXCLUDE[:]
+        )
+        self.threshold = threshold
+
+    def _validate_threshold(self, threshold: float) -> None:
+        """Validate threshold is between 0 and 1."""
+        if not 0 <= threshold <= 1:
+            raise ValueError("threshold must be between 0 and 1")
+
+    def _count_hits(self, text: str) -> Tuple[int, int]:
+        text = text.lower()
+        inc = sum(1 for p in self.include_patterns if p in text)
+        exc = sum(1 for p in self.exclude_patterns if p in text)
+        return inc, exc
+
+    def _calculate_score(self, hits: int, patterns: List[str]) -> float:
+        """Calculate normalized score for pattern hits."""
+        return hits / len(patterns) if patterns else 0.0
+
+    def _scores(self, inc_hits: int, exc_hits: int) -> Tuple[float, float]:
+        """Return inclusion and exclusion scores."""
+        inc_score = self._calculate_score(inc_hits, self.include_patterns)
+        exc_score = self._calculate_score(exc_hits, self.exclude_patterns)
+        return inc_score, exc_score
+
+    def _is_clear_decision(self, score: float, opposite_score: float) -> bool:
+        """Check if score passes threshold and exceeds the opposite score."""
+        return score >= self.threshold and score > opposite_score
+
+
+    def _should_include(self, inc: float, exc: float) -> bool:
+        return self._is_clear_decision(inc, exc)
+
+    def _should_exclude(self, inc: float, exc: float) -> bool:
+        return self._is_clear_decision(exc, inc)
+
+    def _clear_decision_result(self, decision: str, score: float) -> ScreeningResult:
+        return ScreeningResult(
+            decision,
+            score,
+            [f"{decision} score {score:.2f} >= {self.threshold}"]
+        )
+
+    def _include_result(self, score: float) -> ScreeningResult:
+        return self._clear_decision_result("include", score)
+
+    def _exclude_result(self, score: float) -> ScreeningResult:
+        return self._clear_decision_result("exclude", score)
+
+    def _conflict_result(
+        self,
+        inc_hits: int,
+        exc_hits: int,
+        inc_score: float,
+        exc_score: float,
+    ) -> ScreeningResult:
+        if inc_hits > exc_hits:
+            return self._conflict_winner("include", inc_score)
+        if exc_hits > inc_hits:
+            return self._conflict_winner("exclude", exc_score)
+        return self._conflict_tie(inc_score, exc_score)
+
+    def _conflict_winner(self, decision: str, score: float) -> ScreeningResult:
+        return ScreeningResult(decision, score, [f"more {decision} keywords"])
+
+    def _conflict_tie(self, inc_score: float, exc_score: float) -> ScreeningResult:
+        return ScreeningResult(
+            "unsure", max(inc_score, exc_score), ["scores below threshold or tie"]
+        )
+
+    def screen(self, text: str) -> ScreeningResult:
+        """Screen a single text record for inclusion or exclusion."""
+        inc_hits, exc_hits = self._count_hits(text)
+        inc_score, exc_score = self._scores(inc_hits, exc_hits)
+        if self._should_include(inc_score, exc_score):
+            return self._include_result(inc_score)
+        if self._should_exclude(inc_score, exc_score):
+            return self._exclude_result(exc_score)
+        return self._conflict_result(inc_hits, exc_hits, inc_score, exc_score)
+
+    def batch_screen(self, texts: List[str]) -> List[ScreeningResult]:
+        """Screen multiple text records."""
+        return [self.screen(t) for t in texts]
+

--- a/test_prisma_assistant.py
+++ b/test_prisma_assistant.py
@@ -1,0 +1,78 @@
+import pytest
+from knowledge_storm.prisma_assistant import PRISMAScreener
+
+
+def test_screen_include():
+    screener = PRISMAScreener(threshold=0.4)
+    text = "Randomized controlled trial evaluating outcomes"
+    result = screener.screen(text)
+    assert result.decision == "include"
+    assert result.confidence == 0.6
+
+
+def test_screen_conflict_tie_is_unsure():
+    screener = PRISMAScreener(threshold=0.4)
+    text = "Protocol for an upcoming trial"
+    result = screener.screen(text)
+    assert result.decision == "unsure"
+    assert result.confidence == 0.2
+
+
+def test_screen_conflict_include():
+    screener = PRISMAScreener(threshold=0.8)
+    text = "Randomized study protocol"
+    result = screener.screen(text)
+    assert result.decision == "include"
+    assert result.confidence == 0.4
+
+
+def test_screen_unsure():
+    screener = PRISMAScreener()
+    result = screener.screen("Preliminary data")
+    assert result.decision == "unsure"
+    assert result.confidence == 0.0
+
+
+def test_batch_screen():
+    screener = PRISMAScreener(threshold=0.4)
+    records = [
+        "Randomized trial results",
+        "Editorial commentary"
+    ]
+    decisions = [r.decision for r in screener.batch_screen(records)]
+    assert decisions == ["include", "exclude"]
+
+
+def test_empty_patterns():
+    screener = PRISMAScreener(include_patterns=[], exclude_patterns=[])
+    result = screener.screen("anything")
+    assert result.decision == "unsure"
+    assert result.confidence == 0.0
+
+
+def test_tie_hits():
+    screener = PRISMAScreener(
+        include_patterns=["a"],
+        exclude_patterns=["b"],
+        threshold=0.4,
+    )
+    result = screener.screen("a b")
+    assert result.decision == "unsure"
+    assert result.confidence == 1.0
+
+
+def test_empty_text():
+    screener = PRISMAScreener()
+    result = screener.screen("")
+    assert result.decision == "unsure"
+    assert result.confidence == 0.0
+
+
+def test_invalid_threshold():
+    """Test that invalid threshold values raise ValueError."""
+    with pytest.raises(ValueError, match="threshold must be between 0 and 1"):
+        PRISMAScreener(threshold=1.5)
+
+    with pytest.raises(ValueError, match="threshold must be between 0 and 1"):
+        PRISMAScreener(threshold=-0.1)
+


### PR DESCRIPTION
## Summary
- handle empty keyword lists safely
- fix conflict resolution to match documentation
- validate threshold input
- extend tests for empty patterns, ties, and empty text
- add threshold validation tests and clarify tie handling
- prevent shared state and refactor conflict helper methods

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687077238c2083229867e82a6314a3a4